### PR TITLE
0.3.5

### DIFF
--- a/.github/workflows/release-gallery.yml
+++ b/.github/workflows/release-gallery.yml
@@ -1,0 +1,73 @@
+name: Release Gallery Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_psgallery:
+        description: Publish the generated package to PowerShell Gallery
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Build And Publish
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build release package
+        id: build
+        run: |
+          $result = ./build/Build-RenderKitPackage.ps1
+          "version=$($result.Version)" >> $env:GITHUB_OUTPUT
+          "stage_path=$($result.StagePath)" >> $env:GITHUB_OUTPUT
+          "package_path=$($result.PackagePath)" >> $env:GITHUB_OUTPUT
+
+      - name: Upload release package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: RenderKit-${{ steps.build.outputs.version }}-nupkg
+          path: ${{ steps.build.outputs.package_path }}
+          if-no-files-found: error
+
+      - name: Upload staged module artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: RenderKit-${{ steps.build.outputs.version }}-stage
+          path: ${{ steps.build.outputs.stage_path }}
+          if-no-files-found: error
+
+      - name: Ensure PSResourceGet is available
+        if: ${{ inputs.publish_to_psgallery == true }}
+        run: |
+          Import-Module Microsoft.PowerShell.PSResourceGet -Force
+          Get-Command Publish-PSResource -ErrorAction Stop | Out-Null
+
+      - name: Publish package to PowerShell Gallery
+        if: ${{ inputs.publish_to_psgallery == true }}
+        env:
+          NUGETAPIKEY: ${{ secrets.NUGETAPIKEY}}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:NUGETAPIKEY)) {
+              throw 'Missing repository secret NUGETAPIKEY.'
+          }
+
+          Publish-PSResource `
+            -NupkgPath "${{ steps.build.outputs.package_path }}" `
+            -Repository PSGallery `
+            -ApiKey $env:NUGETAPIKEY

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.3.5 - 2026-04-10
+## Patch
+
+## Added
+
+- Added `build/Build-RenderKitPackage.ps1` to stage a lean release artifact and generate a publishable `.nupkg`
+- Added `build/Publish-RenderKit.ps1` to publish the staged package through `PSResourceGet`
+- Added release output ignores for generated `artifacts/`
+
+## Changed
+
+- Switched the release packaging flow to a staged build so gallery packages no longer include repo-only content such as `.git`, workflows, or test files
+- Bundled the published module into a single release `RenderKit.psm1` while keeping the source-split development layout
+- Prepared gallery metadata and release notes for version `0.3.5`
+
 # 0.3.4 - 2026-04-10
 ## Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 - Bundled the published module into a single release `RenderKit.psm1` while keeping the source-split development layout
 - Prepared gallery metadata and release notes for version `0.3.5`
 
+## Fixed
+
+ - Fixed a PSGallery packaging issue where system templates located under `src\Resources\Templates` were not found at runtime because the code only searched `Resources\Templates`. The Lookup is now robust and supports both layouts, including system mappings. 
+ Relevant Files: `RenderKit.StorageService.ps1`, `RenderKit.ImportService.ps1`
+ - Fixed a freezing / unresponsive Powershell window when transferring large files during Import-Media.
+ Replaced `Copy-Item` with stream-based copying and continous progress updates (copy, source hash, staging hash), improving responsiveness and visibility during long operations.
+ Relevant file: `RenderKit.ImportService.ps1`
+
 # 0.3.4 - 2026-04-10
 ## Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 0.3.5 - 2026-04-10
+# 0.3.5 - 2026-04-11
+
 ## Patch
 
 ## Added
@@ -12,16 +13,18 @@
 - Switched the release packaging flow to a staged build so gallery packages no longer include repo-only content such as `.git`, workflows, or test files
 - Bundled the published module into a single release `RenderKit.psm1` while keeping the source-split development layout
 - Prepared gallery metadata and release notes for version `0.3.5`
+- Made some small Code cleanups, scriptanalyzer Bypasses and added some Outputtypes
 
 ## Fixed
 
- - Fixed a PSGallery packaging issue where system templates located under `src\Resources\Templates` were not found at runtime because the code only searched `Resources\Templates`. The Lookup is now robust and supports both layouts, including system mappings. 
+- Fixed a PSGallery packaging issue where system templates located under `src\Resources\Templates` were not found at runtime because the code only searched `Resources\Templates`. The Lookup is now robust and supports both layouts, including system mappings.
  Relevant Files: `RenderKit.StorageService.ps1`, `RenderKit.ImportService.ps1`
- - Fixed a freezing / unresponsive Powershell window when transferring large files during Import-Media.
+- Fixed a freezing / unresponsive Powershell window when transferring large files during Import-Media.
  Replaced `Copy-Item` with stream-based copying and continous progress updates (copy, source hash, staging hash), improving responsiveness and visibility during long operations.
  Relevant file: `RenderKit.ImportService.ps1`
 
 # 0.3.4 - 2026-04-10
+
 ## Patch
 
 ## Changed
@@ -29,40 +32,46 @@
 - Refactored the .psm1 file for robust dot sourcing
 
 # 0.3.3 - 2026-04-04
+
 ## Patch
 
 ---
+
 ## Added
- - Added OutputTypes to some Functions
- - Added ShouldProcess functionalities to some Functions 
+
+- Added OutputTypes to some Functions
+- Added ShouldProcess functionalities to some Functions
 
 ## Changed
 
- - Fixed the error that caused an error at loading the functions. 
+- Fixed the error that caused an error at loading the functions.
 
 ## Removed
 
- - Removed some PluralNouns that make sense. Suppressed some others. 
+- Removed some PluralNouns that make sense. Suppressed some others.
 
 # 0.3.2 - 2026.04.02
+
 ## Patch
 
 ---
 
 ## Changed
 
-- Fixed a minor error in  "FunctionsToExport" segment in the Manifest file. 
+- Fixed a minor error in  "FunctionsToExport" segment in the Manifest file.
 
 # 0.3.1 - 2026-04-02
+
 ## Patch
 
 ---
 
 ## Removed
 
-- Removed trailing white spaces in the code 
+- Removed trailing white spaces in the code
 
 # 0.3.0 – 2026-03-31
+
 ## Minor Release
 
 ---
@@ -70,6 +79,7 @@
 ## Added
 
 ### Import-Media full workflow
+
 - Added interactive import wizard mode when `Import-Media` is called without parameters
 - Added parameter-driven scan/filter mode (`-ScanAndFilter`) with folder/date/wildcard criteria
 - Added optional classification phase to route files by template/mapping rules
@@ -77,11 +87,13 @@
 - Added improved preview and selection flow for matched files
 
 ### Drive detection and source selection
+
 - Added include switches for fixed and unsupported filesystems
 - Added interactive source candidate selection workflow
 - Added whitelist integration for known source devices
 
 ### Backup hardening
+
 - Added ZIP archive creation to backup pipeline
 - Added archive content integrity check against source file hash index
 - Added backup log injection into archive
@@ -114,6 +126,7 @@
 - No changes
 
 # 0.2.0 – 2026-02-11
+
 ## Minor Release
 
 ---
@@ -121,12 +134,14 @@
 ## Added
 
 ### Backup System
+
 - Introduced `Backup-Project`
 - Creates structured backups of RenderKit projects
 - Cleans temporary files, proxy files and software artifacts (WIP) before backup
 - ZIP packaging planned for future release
 
 ### Project Metadata System
+
 - Introduced `.renderkit` folder
 - Added `project.json` containing:
   - Unique Project GUID
@@ -138,15 +153,18 @@
   - Template source
 
 ### Template Engine
+
 - Added multiple project templates
 - Introduced `New-Project -Template`
 - Fallback to `default` template if specified template does not exist
 
 ### Backup Locking
+
 - Implemented `backup.lock` mechanism
 - Prevents concurrent modifications during backup
 
 ### Internal Improvements
+
 - Added internal logging foundation (WIP)
 - Added preparation for future Dry-Run functionality
 
@@ -182,6 +200,7 @@
 - No changes
 
 # 0.1.0 2026.01.29
+
 ## Added
 
 - Added Function "New-Project"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
 **RenderKit** is a PowerShell module for structured video-production workflows.
 It helps you create standardized projects, manage templates/mappings, import media with filter and transfer workflows, and archive projects safely.
 
-## What's new in 0.3.0
+## What's new in 0.3.5
+- Deterministic module exports and loading for cleaner imports across Windows PowerShell and PowerShell 7
+- Staged release packaging for PowerShell Gallery with lean artifacts and a generated publish bundle
+- Maintainer scripts for building and publishing `0.3.5` without dragging `.git`, workflows, or tests into the package
+
+## Core Features
 ### 1) End-to-end media import workflow (`Import-Media`)
 You can now run a full scan → filter → selection → classification → transfer pipeline in one command.
 # Interactive wizard
@@ -68,10 +73,27 @@ Add-RenderKitDeviceWhitelistEntry -FromMountedVolumes
 Install-Module -Name RenderKit
 ```
 
+### Installation with PSResourceGet
+```powershell
+Install-PSResource -Name RenderKit -Repository PSGallery
+```
+
 ### Minimal setup
 ```powershell
 Set-ProjectRoot -Path "D:\Editing_Projects"
 New-Project -Name "WeddingFilm" -Template "youtube"
+```
+
+## Maintainer Release Workflow
+
+Build a clean release artifact:
+```powershell
+pwsh ./build/Build-RenderKitPackage.ps1
+```
+
+Publish the generated package to PowerShell Gallery:
+```powershell
+pwsh ./build/Publish-RenderKit.ps1 -Repository PSGallery -ApiKey '<APIKEY>'
 ```
 
 ---

--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -8,28 +8,14 @@
     Copyright = 'Copyright © 2026 Norbert Marton'
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.1'
-    FunctionsToExport = @(
-        'Add-FolderToTemplate'
-        'Add-RenderKitDeviceWhitelistEntry'
-        'Add-RenderKitMappingToTemplate'
-        'Add-RenderKitTypeToMapping'
-        'Backup-Project'
-        'Get-RenderKitDeviceWhitelist'
-        'Get-RenderKitDriveCandidate'
-        'Import-Media'
-        'New-Project'
-        'New-RenderKitMapping'
-        'New-RenderKitTemplate'
-        'Select-RenderKitDriveCandidate'
-        'Set-ProjectRoot'
-    )
-    CmdletsToExport = @()
+    FunctionsToExport = '*'
+    CmdletsToExport = '*'
     AliasesToExport = '*'
     VariablesToExport = '*'
     PrivateData = @{
         PSData = @{
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags = @('RenderKit', 'renderkit', 'rk', 'rkit', 'render', 'kit', 'video editing', 'cutting', 'production', 'video', 'workflow', 'projectmanagement')
+            Tags = @('RenderKit', 'renderkit', 'rk', 'rkit', 'render', 'kit', 'videoediting', 'cutting', 'production', 'video', 'workflow', 'projectmanagement')
 
             # A URL to the license for this module.
             LicenseUri = 'https://github.com/djtroi/RenderKit?tab=MIT-1-ov-file'

--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -1,36 +1,52 @@
 @{
     RootModule = 'RenderKit.psm1'
-    ModuleVersion = '0.3.4' # Major.Minor.Patch
+    ModuleVersion = '0.3.5' # Major.Minor.Patch
     Author = 'Norbert Marton'
-    Description = 'Powershell tools for video editing project workflows.'
+    Description = 'PowerShell tools for structured video editing project workflows.'
     GUID = '32e3f476-8e44-4511-82c7-952748e6463b'
-    CompanyName = "Concept MARTON"
+    CompanyName = 'Concept MARTON'
     Copyright = 'Copyright © 2026 Norbert Marton'
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.1'
-    FunctionsToExport = '*'
-    CmdletsToExport = '*'
-    AliasesToExport = '*'
-    VariablesToExport = '*'
+    CompatiblePSEditions = @('Desktop', 'Core')
+    FunctionsToExport = @(
+        'Add-FolderToTemplate'
+        'Add-RenderKitDeviceWhitelistEntry'
+        'Add-RenderKitMappingToTemplate'
+        'Add-RenderKitTypeToMapping'
+        'Backup-Project'
+        'Get-RenderKitDeviceWhitelist'
+        'Get-RenderKitDriveCandidate'
+        'Import-Media'
+        'New-Project'
+        'New-RenderKitMapping'
+        'New-RenderKitTemplate'
+        'Select-RenderKitDriveCandidate'
+        'Set-ProjectRoot'
+    )
+    CmdletsToExport = @()
+    AliasesToExport = @(
+        'projectroot'
+        'setroot'
+    )
+    VariablesToExport = @()
     PrivateData = @{
         PSData = @{
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags = @('RenderKit', 'renderkit', 'rk', 'rkit', 'render', 'kit', 'videoediting', 'cutting', 'production', 'video', 'workflow', 'projectmanagement')
+            Tags = @('RenderKit', 'powershell', 'video', 'video-editing', 'media-import', 'backup', 'workflow', 'project-management')
 
             # A URL to the license for this module.
-            LicenseUri = 'https://github.com/djtroi/RenderKit?tab=MIT-1-ov-file'
+            LicenseUri = 'https://github.com/djtroi/RenderKit/blob/main/LICENSE'
 
             # A URL to the main website for this project.
             ProjectUri = 'https://github.com/djtroi/RenderKit'
 
             # A URL to an icon representing this module.
-            IconUri = 'https://raw.githubusercontent.com/djtroi/RenderKit/refs/heads/main/src/assets/RenderKit_Logo.png'
+            IconUri = 'https://raw.githubusercontent.com/djtroi/RenderKit/main/src/assets/RenderKit_Logo.png'
 
             # ReleaseNotes of this module
-            ReleaseNotes = 'https://github.com/djtroi/RenderKit/releases/latest'
-
-
+            ReleaseNotes = 'Prepared version 0.3.5 with a staged release workflow, lean gallery artifacts, and deterministic module packaging.'
         } # End of PSData hashtable
 
-        } # End of PrivateData hashtable
-    }
+    } # End of PrivateData hashtable
+}

--- a/RenderKit.psm1
+++ b/RenderKit.psm1
@@ -1,69 +1,68 @@
-# Module Version
-    # Paths
-    $srcPath     = Join-Path $PSScriptRoot 'src'
-    $publicPath  = Join-Path $srcPath 'Public'
-    $privatePath = Join-Path $srcPath 'Private'
-    $classesPath = Join-Path $srcPath 'Classes'
+$script:RenderKitModuleRoot = $PSScriptRoot
+$script:RenderKitModuleVersion = '0.0.0'
+$script:RenderKitPublicFunctions = @(
+    'Add-FolderToTemplate'
+    'Add-RenderKitDeviceWhitelistEntry'
+    'Add-RenderKitMappingToTemplate'
+    'Add-RenderKitTypeToMapping'
+    'Backup-Project'
+    'Get-RenderKitDeviceWhitelist'
+    'Get-RenderKitDriveCandidate'
+    'Import-Media'
+    'New-Project'
+    'New-RenderKitMapping'
+    'New-RenderKitTemplate'
+    'Select-RenderKitDriveCandidate'
+    'Set-ProjectRoot'
+)
+$script:RenderKitPublicAliases = @(
+    'projectroot'
+    'setroot'
+)
 
-    #define module paths
-    $script:ManifestPath = Join-Path $PSScriptRoot 'RenderKit.psd1'
-    $script:RenderKitModuleRoot = $PSScriptRoot
+$moduleInfo = $ExecutionContext.SessionState.Module
+if ($moduleInfo -and $moduleInfo.Version) {
+    $script:RenderKitModuleVersion = $moduleInfo.Version.ToString()
+}
 
-    #Version
-    if (Test-Path $script:ManifestPath) {
-        $manifest = Import-PowerShellDataFile -Path $script:ManifestPath
-        $script:RenderKitModuleVersion = $manifest.ModuleVersion
+function Register-RenderKitFunction {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    # Compatibility shim for existing source files. The public surface is
+    # defined centrally in the manifest and exported explicitly below.
+    if ($script:RenderKitPublicFunctions -notcontains $Name) {
+        return
     }
-    else {
-        $script:RenderKitModuleVersion = '0.0.0-unknown'
-    }
+}
 
-    # Bootstrap Logging
-    $script:RenderKitLoggingInitialized = $false
-    $script:RenderKitBootstrapLog = New-Object System.Collections.Generic.List[string]
-    $script:RenderKitDebugMode = $false
+function Get-RenderKitSourceFiles {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
 
-    #Snaphot
-    $before = (Get-Command -CommandType Function).Name
-
-    #PRIVATE
-    if (Test-Path $privatePath) {
-        Get-ChildItem $privatePath -Recurse -Filter *.ps1 | ForEach-Object { . $_.FullName }
-    }
-
-    #CLASSES
-    if (Test-Path $classesPath) {
-        Get-ChildItem $classesPath -Recurse -Filter *.ps1 | ForEach-Object { . $_.FullName }
-    }
-
-    #PUBLIC
-    $PublicFunctions = @()
-
-    if (Test-Path $publicPath) {
-        Get-ChildItem $publicPath -Recurse -Filter *.ps1 | ForEach-Object { . $_.FullName }
-
-        foreach ($file in $files) {
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$null)
-            $funcs = $ast.FindAll({param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst]}, $true)
-
-            foreach ($f in $funcs) {
-                $PublicFunctions += $f.Name
-            }
-
-            . $file.FullName
-        }
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
     }
 
-    $after = (Get-Command -CommandType Function).Name
+    Get-ChildItem -LiteralPath $Path -Recurse -File -Filter '*.ps1' |
+        Sort-Object -Property FullName
+}
 
-    #Snapshot after 
-    $after = (Get-Command -CommandType Function).Name
-    $PublicFunctions = $after | Where-Object { $_ -notin $before }
-
-    #EXPORT
-    if ($PublicFunctions.Count -gt 0) {
-        Export-ModuleMember -Function $PublicFunctions
+$srcRoot = Join-Path -Path $PSScriptRoot -ChildPath 'src'
+foreach ($relativePath in 'Classes', 'Private', 'Public') {
+    $folderPath = Join-Path -Path $srcRoot -ChildPath $relativePath
+    foreach ($sourceFile in Get-RenderKitSourceFiles -Path $folderPath) {
+        . $sourceFile.FullName
     }
+}
 
-    
+Set-Alias -Name 'projectroot' -Value 'Set-ProjectRoot' -Scope Script
+Set-Alias -Name 'setroot' -Value 'Set-ProjectRoot' -Scope Script
 
+Export-ModuleMember -Function $script:RenderKitPublicFunctions -Alias $script:RenderKitPublicAliases

--- a/build/Build-RenderKitPackage.ps1
+++ b/build/Build-RenderKitPackage.ps1
@@ -1,0 +1,261 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$OutputRoot = (Join-Path (Split-Path -Parent $PSScriptRoot) 'artifacts'),
+    [switch]$SkipPackage
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-RenderKitStringLiteral {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    return "'{0}'" -f $Value.Replace("'", "''")
+}
+
+function ConvertTo-RenderKitArrayLiteral {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyCollection()]
+        [string[]]$Value
+    )
+
+    if (-not $Value -or $Value.Count -eq 0) {
+        return '@()'
+    }
+
+    $quotedValues = foreach ($item in $Value) {
+        "    {0}" -f (ConvertTo-RenderKitStringLiteral -Value $item)
+    }
+
+    return "@(`r`n{0}`r`n)" -f ($quotedValues -join "`r`n")
+}
+
+function ConvertTo-RenderKitXmlLiteral {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    return [System.Security.SecurityElement]::Escape($Value)
+}
+
+function Get-RenderKitSourceFiles {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -LiteralPath $Path -Recurse -File -Filter '*.ps1' | Sort-Object -Property FullName)
+}
+
+function New-RenderKitDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+}
+
+function New-RenderKitBundledModule {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepositoryRoot,
+
+        [Parameter(Mandatory)]
+        [string]$DestinationPath,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Manifest
+    )
+
+    $builder = New-Object System.Text.StringBuilder
+    $publicFunctionsLiteral = ConvertTo-RenderKitArrayLiteral -Value @($Manifest.FunctionsToExport)
+    $publicAliasesLiteral = ConvertTo-RenderKitArrayLiteral -Value @($Manifest.AliasesToExport)
+    $moduleVersionLiteral = ConvertTo-RenderKitStringLiteral -Value ([string]$Manifest.ModuleVersion)
+
+    [void]$builder.AppendLine('$script:RenderKitModuleRoot = $PSScriptRoot')
+    [void]$builder.AppendLine('$script:RenderKitModuleVersion = {0}' -f $moduleVersionLiteral)
+    [void]$builder.AppendLine('$script:RenderKitPublicFunctions = {0}' -f $publicFunctionsLiteral)
+    [void]$builder.AppendLine('$script:RenderKitPublicAliases = {0}' -f $publicAliasesLiteral)
+    [void]$builder.AppendLine('')
+    [void]$builder.AppendLine('$moduleInfo = $ExecutionContext.SessionState.Module')
+    [void]$builder.AppendLine('if ($moduleInfo -and $moduleInfo.Version) {')
+    [void]$builder.AppendLine('    $script:RenderKitModuleVersion = $moduleInfo.Version.ToString()')
+    [void]$builder.AppendLine('}')
+    [void]$builder.AppendLine('')
+    [void]$builder.AppendLine('function Register-RenderKitFunction {')
+    [void]$builder.AppendLine('    [CmdletBinding()]')
+    [void]$builder.AppendLine('    param(')
+    [void]$builder.AppendLine('        [Parameter(Mandatory)]')
+    [void]$builder.AppendLine('        [string]$Name')
+    [void]$builder.AppendLine('    )')
+    [void]$builder.AppendLine('')
+    [void]$builder.AppendLine('    if ($script:RenderKitPublicFunctions -notcontains $Name) {')
+    [void]$builder.AppendLine('        return')
+    [void]$builder.AppendLine('    }')
+    [void]$builder.AppendLine('}')
+    [void]$builder.AppendLine('')
+
+    foreach ($relativeSourcePath in 'Classes', 'Private', 'Public') {
+        $sourcePath = Join-Path -Path $RepositoryRoot -ChildPath ('src\{0}' -f $relativeSourcePath)
+
+        foreach ($sourceFile in Get-RenderKitSourceFiles -Path $sourcePath) {
+            $relativeFile = $sourceFile.FullName.Substring($RepositoryRoot.Length).TrimStart('\')
+            [void]$builder.AppendLine('# region {0}' -f $relativeFile)
+            [void]$builder.AppendLine((Get-Content -LiteralPath $sourceFile.FullName -Raw).TrimEnd())
+            [void]$builder.AppendLine('# endregion {0}' -f $relativeFile)
+            [void]$builder.AppendLine('')
+        }
+    }
+
+    [void]$builder.AppendLine("Set-Alias -Name 'projectroot' -Value 'Set-ProjectRoot' -Scope Script")
+    [void]$builder.AppendLine("Set-Alias -Name 'setroot' -Value 'Set-ProjectRoot' -Scope Script")
+    [void]$builder.AppendLine('')
+    [void]$builder.AppendLine('Export-ModuleMember -Function $script:RenderKitPublicFunctions -Alias $script:RenderKitPublicAliases')
+
+    Set-Content -LiteralPath $DestinationPath -Value $builder.ToString() -Encoding utf8
+}
+
+function New-RenderKitNuspec {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Manifest,
+
+        [Parameter(Mandatory)]
+        [string]$DestinationPath
+    )
+
+    $psData = $Manifest.PrivateData.PSData
+    $tags = @('PSModule') + @($psData.Tags)
+    $tagString = ($tags | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique) -join ' '
+
+    $nuspec = @"
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>$(ConvertTo-RenderKitXmlLiteral -Value 'RenderKit')</id>
+    <version>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$Manifest.ModuleVersion))</version>
+    <authors>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$Manifest.Author))</authors>
+    <owners>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$Manifest.CompanyName))</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="file">LICENSE</license>
+    <projectUrl>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$psData.ProjectUri))</projectUrl>
+    <icon>images\RenderKit_Logo.png</icon>
+    <readme>README.md</readme>
+    <description>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$Manifest.Description))</description>
+    <releaseNotes>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$psData.ReleaseNotes))</releaseNotes>
+    <copyright>$(ConvertTo-RenderKitXmlLiteral -Value ([string]$Manifest.Copyright))</copyright>
+    <tags>$(ConvertTo-RenderKitXmlLiteral -Value $tagString)</tags>
+    <repository type="git" url="https://github.com/djtroi/RenderKit" branch="main" />
+  </metadata>
+  <files>
+    <file src="RenderKit.psd1" />
+    <file src="RenderKit.psm1" />
+    <file src="README.md" />
+    <file src="CHANGELOG.md" />
+    <file src="LICENSE" />
+    <file src="images\RenderKit_Logo.png" target="images" />
+    <file src="src\Resources\**\*.*" target="src\Resources" />
+  </files>
+</package>
+"@
+
+    Set-Content -LiteralPath $DestinationPath -Value $nuspec -Encoding utf8
+}
+
+$RepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).ProviderPath
+$OutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+
+$manifestPath = Join-Path -Path $RepositoryRoot -ChildPath 'RenderKit.psd1'
+$manifest = Import-PowerShellDataFile -LiteralPath $manifestPath
+$moduleName = 'RenderKit'
+$moduleVersion = [string]$manifest.ModuleVersion
+
+$stageRoot = Join-Path -Path $OutputRoot -ChildPath ('staging\{0}\{1}' -f $moduleName, $moduleVersion)
+$packageRoot = Join-Path -Path $OutputRoot -ChildPath 'packages'
+$tempPackRoot = Join-Path -Path $OutputRoot -ChildPath ('temp\{0}\{1}' -f $moduleName, $moduleVersion)
+$nupkgPath = Join-Path -Path $packageRoot -ChildPath ('{0}.{1}.nupkg' -f $moduleName, $moduleVersion)
+
+New-RenderKitDirectory -Path $stageRoot
+New-Item -ItemType Directory -Path $packageRoot -Force | Out-Null
+New-RenderKitDirectory -Path $tempPackRoot
+
+New-Item -ItemType Directory -Path (Join-Path -Path $stageRoot -ChildPath 'images') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path -Path $stageRoot -ChildPath 'src') -Force | Out-Null
+
+Copy-Item -LiteralPath (Join-Path -Path $RepositoryRoot -ChildPath 'RenderKit.psd1') -Destination (Join-Path -Path $stageRoot -ChildPath 'RenderKit.psd1')
+Copy-Item -LiteralPath (Join-Path -Path $RepositoryRoot -ChildPath 'README.md') -Destination (Join-Path -Path $stageRoot -ChildPath 'README.md')
+Copy-Item -LiteralPath (Join-Path -Path $RepositoryRoot -ChildPath 'CHANGELOG.md') -Destination (Join-Path -Path $stageRoot -ChildPath 'CHANGELOG.md')
+Copy-Item -LiteralPath (Join-Path -Path $RepositoryRoot -ChildPath 'LICENSE') -Destination (Join-Path -Path $stageRoot -ChildPath 'LICENSE')
+Copy-Item -LiteralPath (Join-Path -Path $RepositoryRoot -ChildPath 'src\assets\RenderKit_Logo.png') -Destination (Join-Path -Path $stageRoot -ChildPath 'images\RenderKit_Logo.png')
+Copy-Item -LiteralPath (Join-Path -Path $RepositoryRoot -ChildPath 'src\Resources') -Destination (Join-Path -Path $stageRoot -ChildPath 'src\Resources') -Recurse
+
+New-RenderKitBundledModule -RepositoryRoot $RepositoryRoot -DestinationPath (Join-Path -Path $stageRoot -ChildPath 'RenderKit.psm1') -Manifest $manifest
+New-RenderKitNuspec -Manifest $manifest -DestinationPath (Join-Path -Path $stageRoot -ChildPath 'RenderKit.nuspec')
+
+$csprojPath = Join-Path -Path $tempPackRoot -ChildPath 'RenderKit.Package.csproj'
+$csprojContent = @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+</Project>
+'@
+Set-Content -LiteralPath $csprojPath -Value $csprojContent -Encoding utf8
+
+Remove-Item -LiteralPath $nupkgPath -Force -ErrorAction SilentlyContinue
+
+if (-not $SkipPackage) {
+    $env:DOTNET_CLI_UI_LANGUAGE = 'en-US'
+    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+    $env:DOTNET_NOLOGO = '1'
+    $env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH = '0'
+    $env:DOTNET_CLI_HOME = $OutputRoot
+
+    Push-Location -LiteralPath $stageRoot
+    try {
+        $packOutput = & 'C:\Program Files\dotnet\dotnet.exe' pack $csprojPath ("/p:NuspecFile={0}" -f (Join-Path -Path $stageRoot -ChildPath 'RenderKit.nuspec')) '--output' $packageRoot '--configuration' 'Release' 2>&1
+        foreach ($line in $packOutput) {
+            Write-Host $line
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet pack failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path -Path $stageRoot -ChildPath 'RenderKit.psd1') -Force -ErrorAction Stop | Out-Null
+
+[PSCustomObject]@{
+    ModuleName  = $moduleName
+    Version     = $moduleVersion
+    StagePath   = $stageRoot
+    PackagePath = $nupkgPath
+}

--- a/build/Build-RenderKitPackage.ps1
+++ b/build/Build-RenderKitPackage.ps1
@@ -21,6 +21,7 @@ function ConvertTo-RenderKitStringLiteral {
 
 function ConvertTo-RenderKitArrayLiteral {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [AllowEmptyCollection()]
         [string[]]$Value
@@ -39,6 +40,7 @@ function ConvertTo-RenderKitArrayLiteral {
 
 function ConvertTo-RenderKitXmlLiteral {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [AllowEmptyString()]
         [string]$Value
@@ -48,7 +50,10 @@ function ConvertTo-RenderKitXmlLiteral {
 }
 
 function Get-RenderKitSourceFiles {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+     Justification = 'Function never gets only one file, so Get-RenderKitSourceFiles is actually correct')]
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [Parameter(Mandatory)]
         [string]$Path
@@ -62,6 +67,8 @@ function Get-RenderKitSourceFiles {
 }
 
 function New-RenderKitDirectory {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+     Justification = '"This is not a public Function, that should be tested with -Whatif')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -76,6 +83,8 @@ function New-RenderKitDirectory {
 }
 
 function New-RenderKitBundledModule {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+     Justification = '"This is not a public Function, that should be tested with -Whatif')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -137,6 +146,8 @@ function New-RenderKitBundledModule {
 }
 
 function New-RenderKitNuspec {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+     Justification = '"This is not a public Function, that should be tested with -Whatif')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -238,7 +249,7 @@ if (-not $SkipPackage) {
     try {
         $packOutput = & 'C:\Program Files\dotnet\dotnet.exe' pack $csprojPath ("/p:NuspecFile={0}" -f (Join-Path -Path $stageRoot -ChildPath 'RenderKit.nuspec')) '--output' $packageRoot '--configuration' 'Release' 2>&1
         foreach ($line in $packOutput) {
-            Write-Host $line
+            Write-Output $line
         }
 
         if ($LASTEXITCODE -ne 0) {

--- a/build/Publish-RenderKit.ps1
+++ b/build/Publish-RenderKit.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ApiKey,
+
+    [string]$Repository = 'PSGallery',
+    [string]$DestinationPath,
+    [string]$RepositoryRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$OutputRoot = (Join-Path (Split-Path -Parent $PSScriptRoot) 'artifacts')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$buildScriptPath = Join-Path -Path $PSScriptRoot -ChildPath 'Build-RenderKitPackage.ps1'
+$buildResult = & $buildScriptPath -RepositoryRoot $RepositoryRoot -OutputRoot $OutputRoot
+
+if (-not (Test-Path -LiteralPath $buildResult.PackagePath)) {
+    throw "Expected package '$($buildResult.PackagePath)' was not created."
+}
+
+$publishTarget = if ($DestinationPath) { $DestinationPath } else { $Repository }
+$publishParams = @{
+    NupkgPath = $buildResult.PackagePath
+}
+
+if ($DestinationPath) {
+}
+else {
+    $publishParams.Repository = $Repository
+}
+
+if ($ApiKey) {
+    $publishParams.ApiKey = $ApiKey
+}
+
+if ($PSCmdlet.ShouldProcess($publishTarget, "Publish RenderKit $($buildResult.Version)")) {
+    if ($DestinationPath) {
+        New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null
+        Copy-Item -LiteralPath $buildResult.PackagePath -Destination (Join-Path -Path $DestinationPath -ChildPath (Split-Path -Path $buildResult.PackagePath -Leaf)) -Force
+    }
+    else {
+        Publish-PSResource @publishParams
+    }
+}
+
+$buildResult

--- a/src/Private/Import/RenderKit.ImportService.ps1
+++ b/src/Private/Import/RenderKit.ImportService.ps1
@@ -1682,11 +1682,7 @@ function Read-RenderKitImportMappingFile {
 
     $fileName = Resolve-RenderKitMappingFileName -MappingId $normalizedMappingId
     if (-not [string]::IsNullOrWhiteSpace($fileName)) {
-        if (-not $script:RenderKitModuleRoot) {
-            $script:RenderKitModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-        }
-
-        $systemMappingPath = Join-Path (Join-Path $script:RenderKitModuleRoot "Resources/Mappings") $fileName
+        $systemMappingPath = Get-RenderKitSystemMappingPath -MappingId $normalizedMappingId
         if (-not $candidatePaths.Contains($systemMappingPath)) {
             $candidatePaths.Add($systemMappingPath)
         }
@@ -2249,16 +2245,174 @@ function Get-RenderKitImportFileHashValue {
         [Parameter(Mandatory)]
         [string]$Path,
         [ValidateSet("SHA256", "SHA1", "MD5")]
-        [string]$Algorithm = "SHA256"
+        [string]$Algorithm = "SHA256",
+        [scriptblock]$ProgressCallback
     )
 
+    $bufferSizeBytes = 4MB
+    $buffer = New-Object byte[] $bufferSizeBytes
+    $inputStream = $null
+    $hashAlgorithm = $null
+    $cryptoStream = $null
+    $processedBytes = [int64]0
+    $totalBytes = [int64]0
+    $lastProgressAt = [datetime]::MinValue
+
     try {
-        return [string](Get-FileHash -Path $Path -Algorithm $Algorithm -ErrorAction Stop).Hash
+        switch ($Algorithm) {
+            "SHA256" { $hashAlgorithm = [System.Security.Cryptography.SHA256]::Create() }
+            "SHA1" { $hashAlgorithm = [System.Security.Cryptography.SHA1]::Create() }
+            "MD5" { $hashAlgorithm = [System.Security.Cryptography.MD5]::Create() }
+        }
+
+        $inputStream = New-Object System.IO.FileStream(
+            $Path,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            $bufferSizeBytes,
+            [System.IO.FileOptions]::SequentialScan
+        )
+
+        $totalBytes = [int64]$inputStream.Length
+        $cryptoStream = New-Object System.Security.Cryptography.CryptoStream(
+            [System.IO.Stream]::Null,
+            $hashAlgorithm,
+            [System.Security.Cryptography.CryptoStreamMode]::Write
+        )
+
+        if ($ProgressCallback) {
+            & $ProgressCallback $processedBytes $totalBytes
+        }
+
+        while (($readCount = $inputStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+            $cryptoStream.Write($buffer, 0, $readCount)
+            $processedBytes += $readCount
+
+            $now = Get-Date
+            if (
+                $ProgressCallback -and (
+                    $processedBytes -ge $totalBytes -or
+                    $lastProgressAt -eq [datetime]::MinValue -or
+                    ($now - $lastProgressAt).TotalMilliseconds -ge 150
+                )
+            ) {
+                & $ProgressCallback $processedBytes $totalBytes
+                $lastProgressAt = $now
+            }
+        }
+
+        $cryptoStream.FlushFinalBlock()
+        return ([System.BitConverter]::ToString($hashAlgorithm.Hash)).Replace("-", "")
     }
     catch {
         Write-RenderKitLog -Level Error -Message "Could not calculate $Algorithm hash for '$Path': $($_.Exception.Message)"
         throw
     }
+    finally {
+        if ($cryptoStream) {
+            $cryptoStream.Dispose()
+        }
+
+        if ($hashAlgorithm) {
+            $hashAlgorithm.Dispose()
+        }
+
+        if ($inputStream) {
+            $inputStream.Dispose()
+        }
+    }
+}
+
+function Copy-RenderKitImportFileToPath {
+    [CmdletBinding()]
+    [OutputType([System.Int64])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SourcePath,
+        [Parameter(Mandatory)]
+        [string]$DestinationPath,
+        [scriptblock]$ProgressCallback
+    )
+
+    $bufferSizeBytes = 4MB
+    $buffer = New-Object byte[] $bufferSizeBytes
+    $sourceItem = Get-Item -LiteralPath $SourcePath -ErrorAction Stop
+    $sourceStream = $null
+    $destinationStream = $null
+    $copiedBytes = [int64]0
+    $totalBytes = [int64]$sourceItem.Length
+    $lastProgressAt = [datetime]::MinValue
+
+    try {
+        $sourceStream = New-Object System.IO.FileStream(
+            $sourceItem.FullName,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            $bufferSizeBytes,
+            [System.IO.FileOptions]::SequentialScan
+        )
+
+        $destinationStream = New-Object System.IO.FileStream(
+            $DestinationPath,
+            [System.IO.FileMode]::Create,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::None,
+            $bufferSizeBytes,
+            [System.IO.FileOptions]::SequentialScan
+        )
+
+        if ($ProgressCallback) {
+            & $ProgressCallback $copiedBytes $totalBytes
+        }
+
+        while (($readCount = $sourceStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+            $destinationStream.Write($buffer, 0, $readCount)
+            $copiedBytes += $readCount
+
+            $now = Get-Date
+            if (
+                $ProgressCallback -and (
+                    $copiedBytes -ge $totalBytes -or
+                    $lastProgressAt -eq [datetime]::MinValue -or
+                    ($now - $lastProgressAt).TotalMilliseconds -ge 150
+                )
+            ) {
+                & $ProgressCallback $copiedBytes $totalBytes
+                $lastProgressAt = $now
+            }
+        }
+
+        $destinationStream.Flush()
+    }
+    catch {
+        if (Test-Path -LiteralPath $DestinationPath -PathType Leaf) {
+            Remove-Item -LiteralPath $DestinationPath -Force -ErrorAction SilentlyContinue
+        }
+
+        throw
+    }
+    finally {
+        if ($destinationStream) {
+            $destinationStream.Dispose()
+        }
+
+        if ($sourceStream) {
+            $sourceStream.Dispose()
+        }
+    }
+
+    try {
+        [System.IO.File]::SetCreationTimeUtc($DestinationPath, $sourceItem.CreationTimeUtc)
+        [System.IO.File]::SetLastWriteTimeUtc($DestinationPath, $sourceItem.LastWriteTimeUtc)
+        [System.IO.File]::SetLastAccessTimeUtc($DestinationPath, $sourceItem.LastAccessTimeUtc)
+    }
+    catch {
+        Write-RenderKitLog -Level Warning -Message "Could not preserve timestamps for '$DestinationPath': $($_.Exception.Message)"
+    }
+
+    return $copiedBytes
 }
 
 function Update-RenderKitImportTransferProgress {
@@ -2274,30 +2428,53 @@ function Update-RenderKitImportTransferProgress {
         [int64]$ProcessedBytes,
         [Parameter(Mandatory)]
         [int64]$TotalBytes,
-        [string]$CurrentOperation
+        [string]$CurrentOperation,
+        [int64]$ProgressBytesCompleted = -1,
+        [int64]$ProgressBytesTotal = -1,
+        [string]$Stage,
+        [int64]$CurrentFileProcessedBytes = -1,
+        [int64]$CurrentFileTotalBytes = -1
     )
+
+    if ($ProgressBytesCompleted -lt 0) {
+        $ProgressBytesCompleted = $ProcessedBytes
+    }
+
+    if ($ProgressBytesTotal -lt 0) {
+        $ProgressBytesTotal = $TotalBytes
+    }
 
     $elapsedSeconds = ((Get-Date) - $StartedAt).TotalSeconds
     if ($elapsedSeconds -lt 0.001) {
         $elapsedSeconds = 0.001
     }
 
-    $speedMBps = ([double]$ProcessedBytes / 1MB) / $elapsedSeconds
+    $speedMBps = ([double]$ProgressBytesCompleted / 1MB) / $elapsedSeconds
 
     $percent = 0
-    if ($TotalBytes -gt 0) {
-        $percent = [int][Math]::Min(100, [Math]::Floor(([double]$ProcessedBytes * 100.0) / [double]$TotalBytes))
+    if ($ProgressBytesTotal -gt 0) {
+        $percent = [int][Math]::Min(100, [Math]::Floor(([double]$ProgressBytesCompleted * 100.0) / [double]$ProgressBytesTotal))
     }
     elseif ($TotalCount -gt 0) {
         $percent = [int][Math]::Min(100, [Math]::Floor(([double]$CompletedCount * 100.0) / [double]$TotalCount))
     }
 
-    $status = "{0}/{1} files | {2} / {3} | {4:N2} MB/s" -f `
-        $CompletedCount, `
-        $TotalCount, `
+    $statusSegments = New-Object System.Collections.Generic.List[string]
+    $statusSegments.Add(("{0}/{1} files" -f $CompletedCount, $TotalCount))
+    $statusSegments.Add(("imported {0} / {1}" -f `
         (ConvertTo-RenderKitHumanSize -Bytes $ProcessedBytes), `
-        (ConvertTo-RenderKitHumanSize -Bytes $TotalBytes), `
-        $speedMBps
+        (ConvertTo-RenderKitHumanSize -Bytes $TotalBytes)))
+
+    if ($CurrentFileTotalBytes -ge 0 -and -not [string]::IsNullOrWhiteSpace($Stage)) {
+        $currentFileStatus = "{0} {1} / {2}" -f `
+            $Stage, `
+            (ConvertTo-RenderKitHumanSize -Bytes ([Math]::Max([int64]0, $CurrentFileProcessedBytes))), `
+            (ConvertTo-RenderKitHumanSize -Bytes $CurrentFileTotalBytes)
+        $statusSegments.Add($currentFileStatus)
+    }
+
+    $statusSegments.Add(("{0:N2} MB/s" -f $speedMBps))
+    $status = [string]::Join(" | ", $statusSegments.ToArray())
 
     Write-Progress `
         -Activity "Phase 4 - Transaction-Safe Transfer" `
@@ -2353,6 +2530,8 @@ function Invoke-RenderKitImportTransactionSafeTransfer {
 
     $startTime = Get-Date
     $processedBytes = [int64]0
+    $progressTotalBytes = if ($Simulate) { [int64]$plannedBytes } else { [int64]($plannedBytes * 3) }
+    $completedProgressBytes = [int64]0
     $importedCount = 0
     $simulatedCount = 0
     $failedCount = 0
@@ -2386,6 +2565,7 @@ function Invoke-RenderKitImportTransactionSafeTransfer {
             $errorMessage = $null
             $status = "Pending"
             $bytes = [int64]$file.Length
+            $progressBytesForCurrentFile = if ($Simulate) { $bytes } else { [int64]($bytes * 3) }
 
             try {
                 if ([string]::IsNullOrWhiteSpace($destinationDirectory)) {
@@ -2408,22 +2588,87 @@ function Invoke-RenderKitImportTransactionSafeTransfer {
                         -TotalCount $transferCandidates.Count `
                         -ProcessedBytes $processedBytes `
                         -TotalBytes $plannedBytes `
+                        -ProgressBytesCompleted ($completedProgressBytes + $progressBytesForCurrentFile) `
+                        -ProgressBytesTotal $progressTotalBytes `
+                        -Stage "simulate" `
+                        -CurrentFileProcessedBytes $bytes `
+                        -CurrentFileTotalBytes $bytes `
                         -CurrentOperation ("SIMULATE: {0} -> {1}" -f $file.Name, $destinationRelativePath)
                 }
                 else {
                     $stagingPath = Join-Path $tempRunRoot ("{0:D6}_{1}" -f ($i + 1), $file.Name)
 
-                    Copy-Item -LiteralPath $sourcePath -Destination $stagingPath -Force -ErrorAction Stop
-                    $sourceHash = Get-RenderKitImportFileHashValue -Path $sourcePath -Algorithm $HashAlgorithm
-                    $stagingHash = Get-RenderKitImportFileHashValue -Path $stagingPath -Algorithm $HashAlgorithm
+                    if (-not (Test-Path -Path $destinationDirectory -PathType Container)) {
+                        New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+                    }
+
+                    $copyProgressCallback = {
+                        param([int64]$currentBytes, [int64]$currentTotalBytes)
+
+                        Update-RenderKitImportTransferProgress `
+                            -StartedAt $startTime `
+                            -CompletedCount $completedCount `
+                            -TotalCount $transferCandidates.Count `
+                            -ProcessedBytes $processedBytes `
+                            -TotalBytes $plannedBytes `
+                            -ProgressBytesCompleted ($completedProgressBytes + $currentBytes) `
+                            -ProgressBytesTotal $progressTotalBytes `
+                            -Stage "copy" `
+                            -CurrentFileProcessedBytes $currentBytes `
+                            -CurrentFileTotalBytes $currentTotalBytes `
+                            -CurrentOperation ("COPY: {0} -> {1}" -f $file.Name, $destinationRelativePath)
+                    }
+
+                    $sourceHashProgressCallback = {
+                        param([int64]$currentBytes, [int64]$currentTotalBytes)
+
+                        Update-RenderKitImportTransferProgress `
+                            -StartedAt $startTime `
+                            -CompletedCount $completedCount `
+                            -TotalCount $transferCandidates.Count `
+                            -ProcessedBytes $processedBytes `
+                            -TotalBytes $plannedBytes `
+                            -ProgressBytesCompleted ($completedProgressBytes + $bytes + $currentBytes) `
+                            -ProgressBytesTotal $progressTotalBytes `
+                            -Stage "hash source" `
+                            -CurrentFileProcessedBytes $currentBytes `
+                            -CurrentFileTotalBytes $currentTotalBytes `
+                            -CurrentOperation ("VERIFY SOURCE: {0}" -f $file.Name)
+                    }
+
+                    $stagingHashProgressCallback = {
+                        param([int64]$currentBytes, [int64]$currentTotalBytes)
+
+                        Update-RenderKitImportTransferProgress `
+                            -StartedAt $startTime `
+                            -CompletedCount $completedCount `
+                            -TotalCount $transferCandidates.Count `
+                            -ProcessedBytes $processedBytes `
+                            -TotalBytes $plannedBytes `
+                            -ProgressBytesCompleted ($completedProgressBytes + (2 * $bytes) + $currentBytes) `
+                            -ProgressBytesTotal $progressTotalBytes `
+                            -Stage "hash staging" `
+                            -CurrentFileProcessedBytes $currentBytes `
+                            -CurrentFileTotalBytes $currentTotalBytes `
+                            -CurrentOperation ("VERIFY STAGING: {0}" -f $file.Name)
+                    }
+
+                    Copy-RenderKitImportFileToPath `
+                        -SourcePath $sourcePath `
+                        -DestinationPath $stagingPath `
+                        -ProgressCallback $copyProgressCallback | Out-Null
+                    $sourceHash = Get-RenderKitImportFileHashValue `
+                        -Path $sourcePath `
+                        -Algorithm $HashAlgorithm `
+                        -ProgressCallback $sourceHashProgressCallback
+                    $stagingHash = Get-RenderKitImportFileHashValue `
+                        -Path $stagingPath `
+                        -Algorithm $HashAlgorithm `
+                        -ProgressCallback $stagingHashProgressCallback
 
                     if ($sourceHash -ne $stagingHash) {
                         Write-RenderKitLog -Level Error -Message "Hash mismatch for '$sourcePath'. Source '$sourceHash', staging '$stagingHash'."
                         throw "Hash mismatch for '$sourcePath'. Source '$sourceHash', staging '$stagingHash'."
-                    }
-
-                    if (-not (Test-Path -Path $destinationDirectory -PathType Container)) {
-                        New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
                     }
 
                     Move-Item -LiteralPath $stagingPath -Destination $finalDestinationPath -ErrorAction Stop
@@ -2438,6 +2683,11 @@ function Invoke-RenderKitImportTransactionSafeTransfer {
                         -TotalCount $transferCandidates.Count `
                         -ProcessedBytes $processedBytes `
                         -TotalBytes $plannedBytes `
+                        -ProgressBytesCompleted ($completedProgressBytes + $progressBytesForCurrentFile) `
+                        -ProgressBytesTotal $progressTotalBytes `
+                        -Stage "done" `
+                        -CurrentFileProcessedBytes $bytes `
+                        -CurrentFileTotalBytes $bytes `
                         -CurrentOperation ("TRANSFER: {0} -> {1}" -f $file.Name, $destinationRelativePath)
                 }
             }
@@ -2457,9 +2707,15 @@ function Invoke-RenderKitImportTransactionSafeTransfer {
                     -TotalCount $transferCandidates.Count `
                     -ProcessedBytes $processedBytes `
                     -TotalBytes $plannedBytes `
+                    -ProgressBytesCompleted ($completedProgressBytes + $progressBytesForCurrentFile) `
+                    -ProgressBytesTotal $progressTotalBytes `
+                    -Stage "failed" `
+                    -CurrentFileProcessedBytes ([int64]0) `
+                    -CurrentFileTotalBytes $bytes `
                     -CurrentOperation ("FAILED: {0}" -f $file.Name)
             }
             finally {
+                $completedProgressBytes += $progressBytesForCurrentFile
                 $completedCount++
                 $fileEnd = Get-Date
                 $fileDurationSeconds = ($fileEnd - $fileStart).TotalSeconds

--- a/src/Private/Storage/RenderKit.StorageService.ps1
+++ b/src/Private/Storage/RenderKit.StorageService.ps1
@@ -32,20 +32,52 @@ function Get-RenderKitUserMappingsRoot {
     return $path
 }
 
-function Get-RenderKitSystemTemplatesRoot {
-    if (-not $script:RenderKitModuleRoot) {
-        $script:RenderKitModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+function Get-RenderKitModuleResourceRoot {
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RelativePath
+    )
+
+    $candidateBasePaths = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace([string]$script:RenderKitModuleRoot)) {
+        $candidateBasePaths.Add([string]$script:RenderKitModuleRoot)
     }
 
-    return Join-Path $script:RenderKitModuleRoot "Resources/Templates"
+    $fallbackBasePath = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    if (-not $candidateBasePaths.Contains($fallbackBasePath)) {
+        $candidateBasePaths.Add($fallbackBasePath)
+    }
+
+    foreach ($basePath in $candidateBasePaths) {
+        $resourceCandidates = @(
+            (Join-Path $basePath $RelativePath),
+            (Join-Path (Join-Path $basePath "src") $RelativePath)
+        )
+
+        foreach ($candidatePath in $resourceCandidates) {
+            if (Test-Path -LiteralPath $candidatePath -PathType Container) {
+                return $candidatePath
+            }
+        }
+    }
+
+    $primaryBasePath = $candidateBasePaths[0]
+    $srcBasePath = Join-Path $primaryBasePath "src"
+    if (Test-Path -LiteralPath $srcBasePath -PathType Container) {
+        return Join-Path $srcBasePath $RelativePath
+    }
+
+    return Join-Path $primaryBasePath $RelativePath
+}
+
+function Get-RenderKitSystemTemplatesRoot {
+    return Get-RenderKitModuleResourceRoot -RelativePath "Resources/Templates"
 }
 
 function Get-RenderKitSystemMappingsRoot {
-    if (-not $script:RenderKitModuleRoot) {
-        $script:RenderKitModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    }
-
-    return Join-Path $script:RenderKitModuleRoot "Resources/Mappings"
+    return Get-RenderKitModuleResourceRoot -RelativePath "Resources/Mappings"
 }
 
 function Resolve-RenderKitTemplateFileName {

--- a/src/Public/Add-FolderToTemplate.ps1
+++ b/src/Public/Add-FolderToTemplate.ps1
@@ -1,5 +1,6 @@
-#todo buggy
-<#
+Register-RenderKitFunction "Add-FolderToTemplate"
+function Add-FolderToTemplate {
+    <#
 .SYNOPSIS
 Adds a folder path to an existing RenderKit template.
 
@@ -36,8 +37,6 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Add-FolderToTemplate"
-function Add-FolderToTemplate {
     param(
     [Parameter(Mandatory, Position = 0)]
     [string]$TemplateName,

--- a/src/Public/Add-FolderToTemplate.ps1
+++ b/src/Public/Add-FolderToTemplate.ps1
@@ -36,6 +36,7 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Add-FolderToTemplate"
 function Add-FolderToTemplate {
     param(
     [Parameter(Mandatory, Position = 0)]

--- a/src/Public/Add-RenderKitDeviceWhitelistEntry.ps1
+++ b/src/Public/Add-RenderKitDeviceWhitelistEntry.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Add-RenderKitDeviceWhitelistEntry"
+function Add-RenderKitDeviceWhitelistEntry {
+    <#
 .SYNOPSIS
 Adds device whitelist entries for import source detection.
 
@@ -49,8 +51,6 @@ Get-RenderKitDriveCandidate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Add-RenderKitDeviceWhitelistEntry"
-function Add-RenderKitDeviceWhitelistEntry {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [string[]]$VolumeName,

--- a/src/Public/Add-RenderKitDeviceWhitelistEntry.ps1
+++ b/src/Public/Add-RenderKitDeviceWhitelistEntry.ps1
@@ -49,6 +49,7 @@ Get-RenderKitDriveCandidate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Add-RenderKitDeviceWhitelistEntry"
 function Add-RenderKitDeviceWhitelistEntry {
     [CmdletBinding(SupportsShouldProcess)]
     param(

--- a/src/Public/Add-RenderKitMappingToTemplate.ps1
+++ b/src/Public/Add-RenderKitMappingToTemplate.ps1
@@ -34,6 +34,7 @@ New-RenderKitMapping
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Add-RenderKitMappingToTemplate"
 function Add-RenderKitMappingToTemplate {
     param(
         [string]$TemplateName,

--- a/src/Public/Add-RenderKitMappingToTemplate.ps1
+++ b/src/Public/Add-RenderKitMappingToTemplate.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Add-RenderKitMappingToTemplate"
+function Add-RenderKitMappingToTemplate {
+    <#
 .SYNOPSIS
 Adds a mapping reference to a template.
 
@@ -34,8 +36,6 @@ New-RenderKitMapping
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Add-RenderKitMappingToTemplate"
-function Add-RenderKitMappingToTemplate {
     param(
         [string]$TemplateName,
         [string]$MappingId

--- a/src/Public/Add-RenderKitTypeToMapping.ps1
+++ b/src/Public/Add-RenderKitTypeToMapping.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Add-RenderKitTypeToMapping"
+function Add-RenderKitTypeToMapping {
+    <#
 .SYNOPSIS
 Adds a media type definition to a mapping.
 
@@ -38,8 +40,6 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Add-RenderKitTypeToMapping"
-function Add-RenderKitTypeToMapping {
     param(
         [string]$MappingId,
         [string]$TypeName,

--- a/src/Public/Add-RenderKitTypeToMapping.ps1
+++ b/src/Public/Add-RenderKitTypeToMapping.ps1
@@ -38,6 +38,7 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Add-RenderKitTypeToMapping"
 function Add-RenderKitTypeToMapping {
     param(
         [string]$MappingId,

--- a/src/Public/Backup-Project.ps1
+++ b/src/Public/Backup-Project.ps1
@@ -62,6 +62,7 @@ New-Project
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Backup-Project"
 function Backup-Project{
     [CmdletBinding(SupportsShouldProcess)]
     param(

--- a/src/Public/Backup-Project.ps1
+++ b/src/Public/Backup-Project.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Backup-Project"
+function Backup-Project{
+    <#
 .SYNOPSIS
 Cleans and archives a RenderKit project.
 
@@ -62,8 +64,6 @@ New-Project
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Backup-Project"
-function Backup-Project{
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory, Position = 0)]

--- a/src/Public/Get-RenderKitDeviceWhitelist.ps1
+++ b/src/Public/Get-RenderKitDeviceWhitelist.ps1
@@ -25,6 +25,7 @@ Get-RenderKitDriveCandidate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Get-RenderKitDeviceWhitelist"
 function Get-RenderKitDeviceWhitelist {
     [CmdletBinding()]
     param()

--- a/src/Public/Get-RenderKitDeviceWhitelist.ps1
+++ b/src/Public/Get-RenderKitDeviceWhitelist.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Get-RenderKitDeviceWhitelist"
+function Get-RenderKitDeviceWhitelist {
+    <#
 .SYNOPSIS
 Returns the configured device whitelist.
 
@@ -25,8 +27,6 @@ Get-RenderKitDriveCandidate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Get-RenderKitDeviceWhitelist"
-function Get-RenderKitDeviceWhitelist {
     [CmdletBinding()]
     param()
 

--- a/src/Public/Get-RenderKitDriveCandidate.ps1
+++ b/src/Public/Get-RenderKitDriveCandidate.ps1
@@ -42,6 +42,7 @@ Get-RenderKitDeviceWhitelist
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Get-RenderKitDriveCandidate"
 function Get-RenderKitDriveCandidate {
     [CmdletBinding()]
     [OutputType([System.Object[]])]

--- a/src/Public/Get-RenderKitDriveCandidate.ps1
+++ b/src/Public/Get-RenderKitDriveCandidate.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Get-RenderKitDriveCandidate"
+function Get-RenderKitDriveCandidate {
+    <#
 .SYNOPSIS
 Lists ranked drive candidates for import.
 
@@ -42,8 +44,6 @@ Get-RenderKitDeviceWhitelist
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Get-RenderKitDriveCandidate"
-function Get-RenderKitDriveCandidate {
     [CmdletBinding()]
     [OutputType([System.Object[]])]
     param(

--- a/src/Public/Import-Media.ps1
+++ b/src/Public/Import-Media.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Import-Media"
+function Import-Media {
+    <#
 .SYNOPSIS
 Scans, filters, classifies, and optionally transfers media into a RenderKit project.
 
@@ -107,8 +109,6 @@ Get-Help Import-Media -Detailed
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Import-Media"
-function Import-Media {
      [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
      Justification = '"Media" is already singular (Latin plural of medium, but treated as uncountable in English).')]
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/Public/Import-Media.ps1
+++ b/src/Public/Import-Media.ps1
@@ -107,6 +107,7 @@ Get-Help Import-Media -Detailed
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Import-Media"
 function Import-Media {
      [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
      Justification = '"Media" is already singular (Latin plural of medium, but treated as uncountable in English).')]

--- a/src/Public/New-Project.ps1
+++ b/src/Public/New-Project.ps1
@@ -43,6 +43,7 @@ Get-Help Get-ProjectTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "New-Project"
 function New-Project {
     [CmdletBinding(SupportsShouldProcess)]
     param(

--- a/src/Public/New-Project.ps1
+++ b/src/Public/New-Project.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "New-Project"
+function New-Project {
+    <#
 .SYNOPSIS
 Creates a new project from a template.
 
@@ -43,8 +45,6 @@ Get-Help Get-ProjectTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "New-Project"
-function New-Project {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory, Position = 0)]

--- a/src/Public/New-RenderKitMapping.ps1
+++ b/src/Public/New-RenderKitMapping.ps1
@@ -31,6 +31,7 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "New-RenderKitMapping"
 function New-RenderKitMapping {
     [CmdletBinding(SupportsShouldProcess)]
     param(

--- a/src/Public/New-RenderKitMapping.ps1
+++ b/src/Public/New-RenderKitMapping.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "New-RenderKitMapping"
+function New-RenderKitMapping {
+    <#
 .SYNOPSIS
 Creates a new user mapping file.
 
@@ -31,8 +33,6 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "New-RenderKitMapping"
-function New-RenderKitMapping {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]

--- a/src/Public/New-RenderKitTemplate.ps1
+++ b/src/Public/New-RenderKitTemplate.ps1
@@ -31,6 +31,7 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "New-RenderKitTemplate"
 function New-RenderKitTemplate {
     [CmdletBinding(SupportsShouldProcess)]
     param(

--- a/src/Public/New-RenderKitTemplate.ps1
+++ b/src/Public/New-RenderKitTemplate.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "New-RenderKitTemplate"
+function New-RenderKitTemplate {
+    <#
 .SYNOPSIS
 Creates a new user template file.
 
@@ -31,8 +33,6 @@ Add-RenderKitMappingToTemplate
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "New-RenderKitTemplate"
-function New-RenderKitTemplate {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]

--- a/src/Public/Select-RenderKitDriveCandidate.ps1
+++ b/src/Public/Select-RenderKitDriveCandidate.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Show-RenderKitDriveCadidateTable"
+function Show-RenderKitDriveCandidateTable {
+    <#
 .SYNOPSIS
 Displays drive candidates as a table.
 
@@ -21,8 +23,6 @@ None. Writes a formatted table to host output.
 .LINK
 Get-RenderKitDriveCandidate
 #>
-Register-RenderKitFunction "Show-RenderKitDriveCadidateTable"
-function Show-RenderKitDriveCandidateTable {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]

--- a/src/Public/Select-RenderKitDriveCandidate.ps1
+++ b/src/Public/Select-RenderKitDriveCandidate.ps1
@@ -21,6 +21,7 @@ None. Writes a formatted table to host output.
 .LINK
 Get-RenderKitDriveCandidate
 #>
+Register-RenderKitFunction "Show-RenderKitDriveCadidateTable"
 function Show-RenderKitDriveCandidateTable {
     [CmdletBinding()]
     param(
@@ -49,7 +50,7 @@ function Show-RenderKitDriveCandidateTable {
 
     $displayRows | Format-Table -AutoSize | Out-Host
 }
-
+Register-RenderKitFunction "Read-RenderKitDriveCandidateIndex"
 function Read-RenderKitDriveCandidateIndex {
     <#
     .SYNOPSIS
@@ -107,7 +108,7 @@ function Read-RenderKitDriveCandidateIndex {
         return [int]$selectedIndex
     }
 }
-
+Register-RenderKitFunction "Select-RenderKitDriveCandidate"
 function Select-RenderKitDriveCandidate {
     <#
     .SYNOPSIS

--- a/src/Public/Set-ProjectRoot.ps1
+++ b/src/Public/Set-ProjectRoot.ps1
@@ -1,4 +1,6 @@
-<#
+Register-RenderKitFunction "Set-ProjectRoot"
+function Set-ProjectRoot{
+    <#
 .SYNOPSIS
 Sets the default RenderKit project root path.
 
@@ -31,8 +33,6 @@ Backup-Project
 .LINK
 https://github.com/djtroi/RenderKit
 #>
-Register-RenderKitFunction "Set-ProjectRoot"
-function Set-ProjectRoot{
     [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter(Mandatory)]

--- a/src/Public/Set-ProjectRoot.ps1
+++ b/src/Public/Set-ProjectRoot.ps1
@@ -1,5 +1,3 @@
-New-Alias -Name setroot -Value Set-ProjectRoot
-New-Alias -Name projectroot -Value Set-ProjectRoot
 <#
 .SYNOPSIS
 Sets the default RenderKit project root path.
@@ -33,6 +31,7 @@ Backup-Project
 .LINK
 https://github.com/djtroi/RenderKit
 #>
+Register-RenderKitFunction "Set-ProjectRoot"
 function Set-ProjectRoot{
     [CmdletBinding(SupportsShouldProcess)]
     param (


### PR DESCRIPTION
# 0.3.5 - 2026-04-11
## Patch

## Added

- Added `build/Build-RenderKitPackage.ps1` to stage a lean release artifact and generate a publishable `.nupkg`
- Added `build/Publish-RenderKit.ps1` to publish the staged package through `PSResourceGet`
- Added release output ignores for generated `artifacts/`

## Changed

- Switched the release packaging flow to a staged build so gallery packages no longer include repo-only content such as `.git`, workflows, or test files
- Bundled the published module into a single release `RenderKit.psm1` while keeping the source-split development layout
- Prepared gallery metadata and release notes for version `0.3.5`

## Fixed

 - Fixed a PSGallery packaging issue where system templates located under `src\Resources\Templates` were not found at runtime because the code only searched `Resources\Templates`. The Lookup is now robust and supports both layouts, including system mappings. 
 Relevant Files: `RenderKit.StorageService.ps1`, `RenderKit.ImportService.ps1`
 - Fixed a freezing / unresponsive Powershell window when transferring large files during Import-Media.
 Replaced `Copy-Item` with stream-based copying and continous progress updates (copy, source hash, staging hash), improving responsiveness and visibility during long operations.
 Relevant file: `RenderKit.ImportService.ps1`
