### PR TITLE
Add Remove-Project public cmdlet

### DIFF
--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -19,6 +19,7 @@
         'Get-RenderKitDriveCandidate'
         'Import-Media'
         'New-Project'
+        'Remove-Project'
         'New-RenderKitMapping'
         'New-RenderKitTemplate'
         'Select-RenderKitDriveCandidate'

--- a/RenderKit.psm1
+++ b/RenderKit.psm1
@@ -10,6 +10,7 @@ $script:RenderKitPublicFunctions = @(
     'Get-RenderKitDriveCandidate'
     'Import-Media'
     'New-Project'
+    'Remove-Project'
     'New-RenderKitMapping'
     'New-RenderKitTemplate'
     'Select-RenderKitDriveCandidate'

--- a/src/Private/Global/Get-RenderKitProject.ps1
+++ b/src/Private/Global/Get-RenderKitProject.ps1
@@ -25,7 +25,7 @@ function Get-RenderKitProject{
         $candidate = Join-Path $root $ProjectName
         if (!(Test-Path $candidate)) { continue }
         try {
-            $metaPath = Join-Path $candidate "\.renderkit\project.json"
+            $metaPath = Get-RenderKitProjectMetadataPath -ProjectRoot $candidate
             $meta = Get-Content $metaPath -Raw | ConvertFrom-Json
         }
 

--- a/src/Private/Project/RenderKit.ProjectService.ps1
+++ b/src/Private/Project/RenderKit.ProjectService.ps1
@@ -151,7 +151,7 @@ function Get-RenderKitProjectMetadataPath{
         [string]$ProjectRoot
     )
 
-    return Join-Path $ProjectRoot ".renderkit\project.json"
+    return Join-Path -Path (Join-Path -Path $ProjectRoot -ChildPath ".renderkit") -ChildPath "project.json"
 }
 
 
@@ -217,4 +217,24 @@ function Write-RenderKitProjectMetadata{
     $Metadata |
     ConvertTo-Json -Depth 6 |
     Set-Content -Path $jsonPath -Encoding UTF8
+}
+
+function Remove-RenderKitProjectDirectory {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        "PSUseShouldProcessForStateChangingFunctions",
+        "",
+        Justification = "internal function. The public function already has a DryRun feature and ShouldProcess support"
+    )]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    if (-not (Test-Path -LiteralPath $ProjectRoot -PathType Container)) {
+        Write-RenderKitLog -Level Error -Message "Project folder not found: $ProjectRoot"
+        throw "Project folder not found: $ProjectRoot"
+    }
+
+    Remove-Item -LiteralPath $ProjectRoot -Recurse -Force -ErrorAction Stop
 }

--- a/src/Public/Remove-Project.ps1
+++ b/src/Public/Remove-Project.ps1
@@ -1,0 +1,113 @@
+Register-RenderKitFunction "Remove-Project"
+function Remove-Project {
+    <#
+.SYNOPSIS
+Removes an existing RenderKit project.
+
+.DESCRIPTION
+Resolves a RenderKit project by name and optional base path, validates the project metadata, and removes the complete project folder from disk.
+Supports `-WhatIf` / `-Confirm` via `SupportsShouldProcess`.
+
+.PARAMETER ProjectName
+Name of the project folder to remove.
+
+.PARAMETER Path
+Project root directory that contains the project folder.
+If omitted, the default project root from config is used.
+
+.PARAMETER DryRun
+Simulates project removal without deleting files.
+
+.EXAMPLE
+Remove-Project -ProjectName "ClientA_2026"
+Removes project `ClientA_2026` from the configured default project root.
+
+.EXAMPLE
+Remove-Project -ProjectName "ClientA_2026" -Path "D:\Projects" -WhatIf
+Shows what would be removed from the custom project root without deleting the project.
+
+.EXAMPLE
+Remove-Project -ProjectName "ClientA_2026" -Confirm
+Prompts for confirmation before removing the project.
+
+.INPUTS
+None. You cannot pipe input to this command.
+
+.OUTPUTS
+System.Management.Automation.PSCustomObject
+Returns removal result data (project id, project name, root path, removed flag, dry-run flag).
+
+.LINK
+New-Project
+
+.LINK
+Set-ProjectRoot
+
+.LINK
+https://github.com/djtroi/RenderKit
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$ProjectName,
+        [string]$Path,
+        [switch]$DryRun
+    )
+
+    Write-RenderKitLog -Level Info -Message "Starting removal for project '$ProjectName'."
+    Write-RenderKitLog -Level Debug -Message "Remove-Project started: ProjectName='$ProjectName', Path='$Path', DryRun='$DryRun'."
+
+    $project = Get-RenderKitProject -ProjectName $ProjectName -Path $Path
+    $projectRoot = [string]$project.RootPath
+    $metadataPath = [string]$project.MetadataPath
+
+    $actionDescription = if ($DryRun) {
+        "Simulate removal of RenderKit project folder '$projectRoot'"
+    }
+    else {
+        "Remove RenderKit project folder '$projectRoot'"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($projectRoot, $actionDescription)) {
+        return $null
+    }
+
+    if ($DryRun) {
+        Write-RenderKitLog -Level Info -Message "DryRun mode: project folder '$projectRoot' will not be removed."
+        return [PSCustomObject]@{
+            ProjectName  = [string]$project.Name
+            ProjectId    = [string]$project.Id
+            RootPath     = $projectRoot
+            MetadataPath = $metadataPath
+            Removed      = $false
+            DryRun       = $true
+            ExistsAfter  = [bool](Test-Path -LiteralPath $projectRoot -PathType Container)
+        }
+    }
+
+    try {
+        Remove-RenderKitProjectDirectory -ProjectRoot $projectRoot
+
+        $removed = -not (Test-Path -LiteralPath $projectRoot -PathType Container)
+        if (-not $removed) {
+            Write-RenderKitLog -Level Error -Message "Project folder '$projectRoot' could not be removed."
+            throw "Project folder '$projectRoot' could not be removed."
+        }
+
+        Write-RenderKitLog -Level Info -Message "Project '$($project.Name)' removed successfully from '$projectRoot'."
+
+        return [PSCustomObject]@{
+            ProjectName  = [string]$project.Name
+            ProjectId    = [string]$project.Id
+            RootPath     = $projectRoot
+            MetadataPath = $metadataPath
+            Removed      = $true
+            DryRun       = $false
+            ExistsAfter  = $false
+        }
+    }
+    catch {
+        Write-RenderKitLog -Level Error -Message "Project removal failed: $($_.Exception.Message)"
+        throw
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, consistent public cmdlet to remove RenderKit projects mirroring the conventions used by `New-Project` and other public commands. 
- Centralize destructive filesystem logic in an internal service function and reuse the existing project metadata helpers for robust project resolution.

### Description
- Add `src/Public/Remove-Project.ps1` implementing `Remove-Project` with comment-based help, `SupportsShouldProcess` (`-WhatIf`/`-Confirm`), a `-DryRun` switch, logging and a structured PSCustomObject result. 
- Introduce `Remove-RenderKitProjectDirectory` in `src/Private/Project/RenderKit.ProjectService.ps1` to encapsulate the actual folder removal. 
- Standardize metadata path handling by updating `Get-RenderKitProjectMetadataPath` composition and using it from `src/Private/Global/Get-RenderKitProject.ps1`. 
- Export/register `Remove-Project` in the module loader and manifest by modifying `RenderKit.psm1` and `RenderKit.psd1`.

### Testing
- `python3` wiring check verified presence of `Remove-Project` in manifest/loader and required functions (passed). 
- Ran `git diff --check` to ensure no whitespace/patch issues (passed). 
- Attempted `pwsh -NoLogo -NoProfile -Command "Import-Module ./RenderKit.psd1 -Force; Get-Command Remove-Project -Module RenderKit | Select-Object -ExpandProperty Name"` but it could not be executed because `pwsh` is not installed in the environment (skipped).
- Changes were committed (`Add Remove-Project cmdlet`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3141f277b083229e97fdd08a85afed)