### PR TITLE
Fix media import classification, progress, and preview scaling

### DIFF
--- a/Tests/Import/RenderKit.ImportService.Tests.ps1
+++ b/Tests/Import/RenderKit.ImportService.Tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    $repositoryRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    . (Join-Path $repositoryRoot 'src/Private/Storage/RenderKit.StorageService.ps1')
+    . (Join-Path $repositoryRoot 'src/Private/Import/RenderKit.ImportService.ps1')
+    function Write-RenderKitLog { param([string]$Level, [string]$Message) }
+}
+
+Describe 'RenderKit import service' {
+    It 'loads a system mapping after the storage path normalization change' {
+        $systemMappingPath = Join-Path $TestDrive 'video.json'
+        '{"Id":"video","Types":[]}' |
+            Set-Content -LiteralPath $systemMappingPath
+
+        Mock Get-RenderKitUserMappingPath {
+            Join-Path $TestDrive 'missing-user-mapping.json'
+        }
+        Mock Get-RenderKitSystemMappingPath { $systemMappingPath }
+
+        $mapping = Read-RenderKitImportMappingFile -MappingId 'video'
+
+        $mapping.Id | Should -Be 'video'
+        Should -Invoke Get-RenderKitSystemMappingPath `
+            -Exactly 1 `
+            -ParameterFilter { $MappingId -eq 'video' }
+    }
+
+    It 'only materializes rows that are visible in the import preview' {
+        Mock Write-RenderKitLog
+        $files = for ($index = 0; $index -lt 20; $index++) {
+            $file = [PSCustomObject]@{
+                RelativeDirectory = '.'
+                LastWriteTime = [datetime]::UtcNow
+                Length = [int64]1
+            }
+            if ($index -lt 3) {
+                $file | Add-Member -NotePropertyName Name -NotePropertyValue "file-$index.mov"
+            }
+            else {
+                $file | Add-Member -MemberType ScriptProperty -Name Name -Value {
+                    throw 'A non-visible preview row was materialized.'
+                }
+            }
+            $file
+        }
+
+        Show-RenderKitImportPreviewTable `
+            -Files $files `
+            -PreviewCount 3 `
+            -Title 'Bounded preview'
+
+        Should -Invoke Write-RenderKitLog `
+            -ParameterFilter {
+                $Message -eq 'Showing first 3 of 20 file(s).'
+            }
+    }
+}

--- a/src/Private/Import/RenderKit.ImportService.ps1
+++ b/src/Private/Import/RenderKit.ImportService.ps1
@@ -870,19 +870,20 @@ function Show-RenderKitImportPreviewTable {
         $PreviewCount = 1
     }
 
-    $rows = @()
-    for ($i = 0; $i -lt $Files.Count; $i++) {
+    $rows = New-Object System.Collections.Generic.List[object]
+    $previewLimit = [Math]::Min($Files.Count, $PreviewCount)
+    for ($i = 0; $i -lt $previewLimit; $i++) {
         $file = $Files[$i]
-        $rows += [PSCustomObject]@{
+        $rows.Add([PSCustomObject]@{
             Index     = $i
             Name      = $file.Name
             Folder    = if ($file.RelativeDirectory -eq ".") { "<root>" } else { $file.RelativeDirectory }
             LastWrite = $file.LastWriteTime.ToString("yyyy-MM-dd HH:mm:ss")
             Size      = ConvertTo-RenderKitHumanSize -Bytes ([int64]$file.Length)
-        }
+        })
     }
 
-    $rows | Select-Object -First $PreviewCount | Format-Table -AutoSize | Out-Host
+    $rows | Format-Table -AutoSize | Out-Host
 
     if ($Files.Count -gt $PreviewCount) {
         Write-RenderKitLog -Level Info -Message "Showing first $PreviewCount of $($Files.Count) file(s)."
@@ -1249,12 +1250,9 @@ function Read-RenderKitImportMappingFile {
     $candidatePaths = New-Object System.Collections.Generic.List[string]
     $candidatePaths.Add((Get-RenderKitUserMappingPath -MappingId $normalizedMappingId))
 
-    $fileName = Resolve-RenderKitMappingFileName -MappingId $normalizedMappingId
-    if (-not [string]::IsNullOrWhiteSpace($fileName)) {
-        $systemMappingPath = Get-RenderKitSystemMappingPath -MappingId $normalizedMappingId
-        if (-not $candidatePaths.Contains($systemMappingPath)) {
-            $candidatePaths.Add($systemMappingPath)
-        }
+    $systemMappingPath = Get-RenderKitSystemMappingPath -MappingId $normalizedMappingId
+    if (-not $candidatePaths.Contains($systemMappingPath)) {
+        $candidatePaths.Add($systemMappingPath)
     }
 
     foreach ($path in $candidatePaths) {
@@ -1535,19 +1533,20 @@ function Show-RenderKitImportClassificationPreview {
         $PreviewCount = 1
     }
 
-    $rows = @()
-    for ($i = 0; $i -lt $Files.Count; $i++) {
+    $rows = New-Object System.Collections.Generic.List[object]
+    $previewLimit = [Math]::Min($Files.Count, $PreviewCount)
+    for ($i = 0; $i -lt $previewLimit; $i++) {
         $file = $Files[$i]
-        $rows += [PSCustomObject]@{
+        $rows.Add([PSCustomObject]@{
             Index          = $i
             Name           = $file.Name
             Extension      = if ([string]::IsNullOrWhiteSpace($file.NormalizedExtension)) { "<none>" } else { $file.NormalizedExtension }
             Classification = $file.Classification
             Destination    = if ([string]::IsNullOrWhiteSpace($file.DestinationRelativePath)) { "-" } else { $file.DestinationRelativePath }
-        }
+        })
     }
 
-    $rows | Select-Object -First $PreviewCount | Format-Table -AutoSize | Out-Host
+    $rows | Format-Table -AutoSize | Out-Host
     if ($Files.Count -gt $PreviewCount) {
         Write-RenderKitLog -Level Info -Message "Showing first $PreviewCount of $($Files.Count) file(s)."
     }
@@ -2094,11 +2093,12 @@ function Update-RenderKitImportTransferProgress {
     $statusSegments.Add(("{0:N2} MB/s" -f $speedMBps))
     $status = [string]::Join(" | ", $statusSegments.ToArray())
 
+    $overallPercent = 55 + [int][Math]::Floor($percent * 0.35)
     Write-Progress `
         -Activity "Phase 4 - Transaction-Safe Transfer" `
         -Status $status `
         -CurrentOperation $CurrentOperation `
-        -PercentComplete $percent
+        -PercentComplete $overallPercent
 }
 
 function Get-RenderKitImportTransferSchedulerConfiguration {

--- a/src/Public/Import-Media.ps1
+++ b/src/Public/Import-Media.ps1
@@ -231,6 +231,10 @@ https://github.com/djtroi/RenderKit
     }
 
     $importStartedAt = Get-Date
+    Write-Progress `
+        -Activity "Import media" `
+        -Status "Resolving import source" `
+        -PercentComplete 2
 
     $resolvedSourcePath = Resolve-RenderKitImportSourcePath `
         -SourcePath $SourcePath `
@@ -257,7 +261,15 @@ https://github.com/djtroi/RenderKit
 
     Write-Information "Phase 2: scanning source '$resolvedSourcePath'..." -InformationAction Continue
     Write-RenderKitLog -Level Info -Message "Phase 2: scanning source '$resolvedSourcePath'..."
+    Write-Progress `
+        -Activity "Import media" `
+        -Status "Scanning source files" `
+        -PercentComplete 5
     $catalog = @(Get-RenderKitImportFileCatalog -SourcePath $resolvedSourcePath)
+    Write-Progress `
+        -Activity "Import media" `
+        -Status "Filtering $($catalog.Count) scanned file(s)" `
+        -PercentComplete 20
 
     $criteria = New-RenderKitImportCriterion `
         -FolderFilter $FolderFilter `
@@ -301,6 +313,10 @@ https://github.com/djtroi/RenderKit
             -Files $matchedFiles `
             -AutoSelectAll:$AutoSelectAll
     )
+    Write-Progress `
+        -Activity "Import media" `
+        -Status "Selected $($selectedFiles.Count) of $($matchedFiles.Count) matched file(s)" `
+        -PercentComplete 35
 
     if ($selectedFiles.Count -eq 0) {
         Write-RenderKitLog -Level Info -Message "No files selected for import."
@@ -373,6 +389,10 @@ https://github.com/djtroi/RenderKit
     $classificationResult = $null
     if ($shouldClassify -and $confirmed -and $selectedFiles.Count -gt 0) {
         Write-Information "Phase 3: classifying selected files..." -InformationAction Continue
+        Write-Progress `
+            -Activity "Import media" `
+            -Status "Classifying $($selectedFiles.Count) selected file(s)" `
+            -PercentComplete 40
 
         $effectiveUnassignedHandling = $UnassignedHandling
 
@@ -387,6 +407,10 @@ https://github.com/djtroi/RenderKit
             -Files $classificationResult.Files `
             -PreviewCount $PreviewCount `
             -Title "Phase 3 classification"
+        Write-Progress `
+            -Activity "Import media" `
+            -Status "Classification completed" `
+            -PercentComplete 55
     }
     elseif ($shouldClassify -and $selectedFiles.Count -eq 0) {
         Write-RenderKitLog -Level Info -Message "Phase 3 skipped because no files were selected."
@@ -454,6 +478,10 @@ https://github.com/djtroi/RenderKit
 
         if ($simulateTransfer -or $executeTransfer) {
             Write-Information "Phase 4: transaction-safe transfer..." -InformationAction Continue
+            Write-Progress `
+                -Activity "Import media" `
+                -Status "Transferring $($classificationResult.Files.Count) classified file(s)" `
+                -PercentComplete 56
             $transferResult = Invoke-RenderKitImportTransactionSafeTransfer `
                 -ClassifiedFiles $classificationResult.Files `
                 -ProjectRoot $classificationResult.ProjectRoot `
@@ -524,6 +552,10 @@ https://github.com/djtroi/RenderKit
     }
 
     $importEndedAt = Get-Date
+    Write-Progress `
+        -Activity "Import media" `
+        -Status "Finalizing import report" `
+        -PercentComplete 92
     $finalReport = New-RenderKitImportFinalReport `
         -ImportStartedAt $importStartedAt `
         -ImportEndedAt $importEndedAt `
@@ -596,6 +628,10 @@ https://github.com/djtroi/RenderKit
         [int]$transferResult.ImportedFileCount -gt 0) {
         try {
             Write-RenderKitLog -Level Info -Message "Phase 6 metadata extraction started for '$effectiveProjectRoot'."
+            Write-Progress `
+                -Activity "Import media" `
+                -Status "Extracting imported media metadata" `
+                -PercentComplete 95
             $metadataExtraction = Update-RenderKitProjectMetadataCache `
                 -ProjectRoot $effectiveProjectRoot `
                 -ThrottleLimit $MetadataThrottleLimit
@@ -613,6 +649,8 @@ https://github.com/djtroi/RenderKit
     elseif ($IncludeMetadata -and $Transfer) {
         Write-RenderKitLog -Level Debug -Message "Phase 6 metadata extraction skipped: no successful real transfer was detected."
     }
+
+    Write-Progress -Activity "Import media" -Completed
 
     return [PSCustomObject]@{
         SourcePath         = $resolvedSourcePath


### PR DESCRIPTION
## What changed

- remove the stale `Resolve-RenderKitMappingFileName` dependency and resolve system mappings through the current storage helpers
- emit structured phase progress throughout `Import-Media`
- map transfer progress into the overall import range
- materialize only visible preview rows instead of building rows for every scanned file
- add regression coverage for system mapping lookup and bounded preview work

## Root cause

The storage/versioning refactor removed `Resolve-RenderKitMappingFileName`, but the import classification path still called it. Large imports also built complete preview arrays twice with repeated array growth, even though only a small preview was rendered.

## Impact

Media import can classify mapped files again, large source scans avoid unnecessary preview work, and hosts can consume real phase and transfer progress.

## Validation

- `pwsh -NoProfile -File build/Invoke-RenderKitTests.ps1 -Path ./Tests/Import` (20 passed)
- bundled into RenderKit Studio and exercised through the packaged broker media-import smoke test