### PR TITLE
RS-1129: Probe hardware encoders before backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 # Changelog
+
+## 1.1.3 - 2026-07-31
+
+### Added
+
+- Added RS-798/RS-799 worker capability discovery for local and registered
+  backup workers, including per-worker CPU, GPU, FFmpeg, and encoder support.
+- Added per-worker backup-profile execution results with eligible worker IDs,
+  compatibility states, and CPU-fallback reporting without preventing users
+  from storing structurally valid custom profiles.
+- Added RS-1204 machine-readable and documented RenderKit file-format
+  definitions for the ZIP-based `.rkit` and `.rkitpkg` project archives.
+
+### Changed
+
+- RS-1204 project exports now always append the canonical `.rkit` or
+  `.rkitpkg` extension when another extension is requested, normalize canonical
+  extension casing, and continue returning the effective output path.
+- RS-798/RS-799 hardware validation now evaluates every available worker
+  independently and preserves offline worker registrations for heterogeneous
+  future worker pools.
+
+### Fixed
+
+- Fixed RS-1129 automatic encoder selection treating an FFmpeg encoder as
+  usable when the installed GPU cannot execute it. Hardware encoders are now
+  probed with a real one-frame encode at supported dimensions and safely fall
+  back to a compatible CPU encoder.
+
 ## 1.1.2 - 2026-07-23
 
 ### Added

--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -21,6 +21,7 @@
         'Backup-Project'
         'Get-BackupAdapter'
         'Get-BackupConfigProfile'
+        'Get-BackupWorkerCapability'
         'Get-BackupJob'
         'Get-Metadata'
         'Get-MetadataTemplate'

--- a/RenderKit.psm1
+++ b/RenderKit.psm1
@@ -12,6 +12,7 @@ $script:RenderKitPublicFunctions = @(
     'Backup-Project'
     'Get-BackupAdapter'
     'Get-BackupConfigProfile'
+    'Get-BackupWorkerCapability'
     'Get-BackupJob'
     'Get-Metadata'
     'Get-MetadataTemplate'

--- a/Tests/Backup/RenderKit.BackupCommandContract.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupCommandContract.Tests.ps1
@@ -97,6 +97,7 @@ Describe 'RenderKit backup command contracts' {
     It 'exposes the backup config profile creator lifecycle' {
         foreach ($commandName in @(
                 'New-BackupConfigProfile',
+                'Get-BackupWorkerCapability',
                 'Set-BackupConfigProfile',
                 'Test-BackupConfigProfile',
                 'Export-BackupConfigProfile',

--- a/Tests/Backup/RenderKit.BackupConfigProfile.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupConfigProfile.Tests.ps1
@@ -259,6 +259,105 @@ Describe 'RenderKit backup config profile creator' {
         @(Get-BackupConfigProfile -Source User).Count | Should -Be 0
     }
 
+    It 'keeps structurally valid profiles while reporting worker incompatibility' {
+        $workers = @(
+            [PSCustomObject]@{
+                workerId = 'worker-h264'
+                machine = 'encode-01'
+                online = $true
+                devices = @(
+                    [PSCustomObject]@{
+                        id = 'CPU'
+                        codecs = @('H264', 'H265')
+                    }
+                    [PSCustomObject]@{
+                        id = 'Nvidia'
+                        codecs = @('H264')
+                    }
+                )
+            }
+        )
+
+        $result = Test-BackupConfigProfile `
+            -Name smallest `
+            -CheckHardware `
+            -WorkerCapability $workers
+
+        $result.IsValid | Should -BeTrue
+        $result.ExecutionCompatibility.Status | Should -Be 'Unavailable'
+        $result.ExecutionCompatibility.IsExecutable | Should -BeFalse
+        $result.ExecutionCompatibility.ResolvedCodec | Should -Be 'AV1'
+        $result.ExecutionCompatibility.Workers[0].Reason |
+            Should -Be 'NoCompatibleEncoder'
+    }
+
+    It 'evaluates heterogeneous workers independently' {
+        $workers = @(
+            [PSCustomObject]@{
+                workerId = 'worker-h264'
+                machine = 'encode-01'
+                online = $true
+                devices = @(
+                    [PSCustomObject]@{
+                        id = 'CPU'
+                        codecs = @('H264')
+                    }
+                    [PSCustomObject]@{
+                        id = 'Nvidia'
+                        codecs = @('H264')
+                    }
+                )
+            }
+            [PSCustomObject]@{
+                workerId = 'worker-av1'
+                machine = 'encode-02'
+                online = $true
+                devices = @(
+                    [PSCustomObject]@{
+                        id = 'CPU'
+                        codecs = @('H264', 'H265', 'AV1')
+                    }
+                    [PSCustomObject]@{
+                        id = 'IntelQuickSync'
+                        codecs = @('H264', 'H265', 'AV1')
+                    }
+                )
+            }
+        )
+
+        $result = Test-BackupConfigProfile `
+            -Name smallest `
+            -CheckHardware `
+            -WorkerCapability $workers
+
+        $result.ExecutionCompatibility.Status | Should -Be 'Degraded'
+        $result.ExecutionCompatibility.IsExecutable | Should -BeTrue
+        $result.ExecutionCompatibility.CompatibleWorkerIds |
+            Should -Contain 'worker-av1'
+        $result.ExecutionCompatibility.CompatibleWorkerIds |
+            Should -Not -Contain 'worker-h264'
+        $result.ExecutionCompatibility.Workers.Count | Should -Be 2
+    }
+
+    It 'does not require an encoder for archive-only profiles' {
+        $worker = [PSCustomObject]@{
+            workerId = 'archive-worker'
+            machine = 'archive-01'
+            online = $true
+            devices = @()
+        }
+
+        $result = Test-BackupConfigProfile `
+            -Name no-transcode `
+            -CheckHardware `
+            -WorkerCapability @($worker)
+
+        $result.ExecutionCompatibility.Status | Should -Be 'Available'
+        $result.ExecutionCompatibility.IsExecutable | Should -BeTrue
+        $result.ExecutionCompatibility.Workers[0].Reason |
+            Should -Be 'NoEncodingRequired'
+    }
+
     It 'rebases an existing user profile while applying explicit settings' {
         New-BackupConfigProfile `
             -Name rebase-me `

--- a/Tests/Backup/RenderKit.BackupProjectJob.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupProjectJob.Tests.ps1
@@ -1826,6 +1826,44 @@ Describe 'RenderKit BackupProject job planning' {
         $profile.encoderSelection.reason | Should -Be 'NoUsableHardwareEncoderDetected'
     }
 
+    It 'falls back to CPU when RS-1129 hardware probing rejects an advertised encoder' {
+        $profile = InModuleScope RenderKit {
+            $capabilities = New-BackupGpuCapabilityReport `
+                -EncoderNames @('h264_nvenc', 'hevc_nvenc', 'av1_nvenc') `
+                -VideoControllerNames @('NVIDIA GeForce GTX 1080 Ti') `
+                -DetectedCommands @('nvidia-smi') `
+                -FfmpegPath 'ffmpeg' `
+                -Source 'Test' `
+                -EncoderProbeResults @{
+                    h264_nvenc = [PSCustomObject]@{
+                        usable = $true
+                        reason = 'ProbeSucceeded'
+                    }
+                    hevc_nvenc = [PSCustomObject]@{
+                        usable = $true
+                        reason = 'ProbeSucceeded'
+                    }
+                    av1_nvenc = [PSCustomObject]@{
+                        usable = $false
+                        reason = 'ProbeFailed'
+                    }
+                } `
+                -RunBenchmark
+            Get-BackupEncodingProfile `
+                -CompressionPreset Smallest `
+                -VideoCodec AV1 `
+                -EncoderDevice Auto `
+                -QualityPreset Smallest `
+                -AudioProfile Auto `
+                -GpuCapabilities $capabilities
+        }
+
+        $profile.videoCodec | Should -Be 'AV1'
+        $profile.encoderDevice | Should -Be 'CPU'
+        $profile.encoderName | Should -Be 'libsvtav1'
+        $profile.encoderSelection.source | Should -Be 'CpuFallback'
+    }
+
     It 'persists and reads the GPU capability cache' {
         $cached = InModuleScope RenderKit -Parameters @{
             CachePath = (Join-Path $TestDrive 'gpu-cache\gpu-capabilities.json')

--- a/Tests/Public/Export-Project.Tests.ps1
+++ b/Tests/Public/Export-Project.Tests.ps1
@@ -20,6 +20,7 @@ BeforeAll {
 
 Describe 'Export-Project' {
     BeforeEach {
+        $script:RenderKitFileFormatCatalog = $null
         $script:RenderKitArtifactVersionCatalog = $null
         $script:RenderKitArtifactMigrations = @{}
         $script:RenderKitModuleVersion = '0.0.0'
@@ -47,5 +48,84 @@ Describe 'Export-Project' {
         $expectedPath = Join-Path $destinationRoot 'ProjectA.rkit'
         $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
         Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'appends the canonical manifest extension to an arbitrary file extension' {
+        $projectRoot = Join-Path $TestDrive 'ProjectB'
+        $requestedPath = Join-Path $TestDrive 'exporttest.txt'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode ManifestOnly
+
+        $expectedPath = "$requestedPath.rkit"
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $requestedPath -PathType Leaf |
+            Should -BeFalse
+    }
+
+    It 'appends the canonical package extension for self-contained exports' {
+        $projectRoot = Join-Path $TestDrive 'ProjectC'
+        $requestedPath = Join-Path $TestDrive 'portable.zip'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode SelfContained
+
+        $expectedPath = "$requestedPath.rkitpkg"
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'normalizes the casing of an otherwise canonical extension' {
+        $projectRoot = Join-Path $TestDrive 'ProjectD'
+        $requestedPath = Join-Path $TestDrive 'manifest.RKIT'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode ManifestOnly
+
+        $expectedPath = Join-Path $TestDrive 'manifest.rkit'
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'writes both RenderKit project formats as readable zip archives' {
+        $projectRoot = Join-Path $TestDrive 'ProjectE'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        foreach ($mode in @('ManifestOnly', 'SelfContained')) {
+            $requestedPath = Join-Path $TestDrive $mode
+            $result = Export-Project `
+                -ProjectRoot $projectRoot `
+                -DestinationPath $requestedPath `
+                -Mode $mode
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($result.Path)
+            try {
+                $archive.GetEntry('project.xml') | Should -Not -BeNullOrEmpty
+            }
+            finally {
+                $archive.Dispose()
+            }
+        }
     }
 }

--- a/build/Test-RenderKitPackage.ps1
+++ b/build/Test-RenderKitPackage.ps1
@@ -34,6 +34,7 @@ try {
         'src/Resources/Metadata/ixml-field-map.json',
         'src/Resources/Metadata/iptc-field-map.json',
         'src/Resources/Metadata/matroska-field-map.json',
+        'src/Resources/FileFormats/RenderKit.FileFormats.json',
         'src/Resources/ThirdParty/MediaInfo/manifest.json',
         'src/Resources/ThirdParty/ExifTool/manifest.json',
         'src/Resources/ThirdParty/ExifTool/files.sha256',

--- a/docs/Export-Project.md
+++ b/docs/Export-Project.md
@@ -21,7 +21,7 @@ Export-Project -ProjectRoot <string> -DestinationPath <string> [-Mode <string>] 
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `-ProjectRoot` | `string` | Yes | – | Full path to the project directory. |
-| `-DestinationPath` | `string` | Yes | – | Destination file path for the manifest/package, or an existing destination directory. Directory destinations create `<ProjectRootName>.rkit` for `ManifestOnly` exports and `<ProjectRootName>.rkitpkg` for `SelfContained` exports. |
+| `-DestinationPath` | `string` | Yes | – | Destination file path for the manifest/package, or an existing destination directory. RenderKit always appends the canonical `.rkit` or `.rkitpkg` extension when it is missing or another extension was supplied. Directory destinations create `<ProjectRootName>.rkit` for `ManifestOnly` exports and `<ProjectRootName>.rkitpkg` for `SelfContained` exports. |
 | `-Mode` | `string` | No | `'ManifestOnly'` | Export mode. |
 | `-CompressionMethod` | `string` | No | `'Zip'` | Compression method. |
 | `-CompressionLevel` | `string` | No | `'Optimal'` | Compression level. |
@@ -36,6 +36,19 @@ Export-Project -ProjectRoot "D:\Projects\ClientA" -DestinationPath "E:\Transfer"
 ```
 
 Exports `D:\Projects\ClientA` to `E:\Transfer\ClientA.rkit`.
+
+If a non-RenderKit extension is supplied, it remains part of the base file
+name and the canonical extension is appended:
+
+```powershell
+Export-Project `
+  -ProjectRoot "D:\Projects\ClientA" `
+  -DestinationPath "E:\Transfer\ClientA.zip" `
+  -Mode SelfContained
+```
+
+This writes `E:\Transfer\ClientA.zip.rkitpkg`. Existing files at the originally
+requested non-RenderKit path are not overwritten.
 
 
 Before running the command, inspect its full help with `Get-Help Export-Project -Full`. For commands that support `ShouldProcess`, use `-WhatIf` before making production changes.

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1,0 +1,36 @@
+# RenderKit file formats
+
+RenderKit-owned portable artifacts use a RenderKit-specific extension. The
+extension identifies the domain artifact; its underlying serialization remains
+available to standard tooling.
+
+## Active project formats
+
+| Extension | Artifact | Container | Media type |
+| --- | --- | --- | --- |
+| `.rkit` | Project manifest and portable resources | ZIP | `application/vnd.renderkit.project+zip` |
+| `.rkitpkg` | Self-contained project package including project files | ZIP | `application/vnd.renderkit.project-package+zip` |
+
+Both formats are valid ZIP archives and contain `project.xml` at the archive
+root. Operating-system integration may therefore classify them as ZIP-based
+archives without changing their RenderKit-specific extension.
+
+The machine-readable format identifiers used by Core and packaging integrations
+are stored in `src/Resources/FileFormats/RenderKit.FileFormats.json`.
+
+## Reserved portable artifact extensions
+
+The following extensions are reserved for future or migrated portability
+commands. Reserving them does not change the internal JSON files used by the
+RenderKit runtime.
+
+| Extension | Intended artifact |
+| --- | --- |
+| `.rkittemplate` | Portable project or metadata template |
+| `.rkitmapping` | Portable media mapping |
+| `.rkitprofile` | Portable backup or workflow profile |
+| `.rkitmetadata` | Portable metadata export |
+| `.rkitjobs` | Portable job-history collection |
+
+RenderKit types remain part of a mapping. A separate type extension should only
+be introduced if types become independently versioned and portable artifacts.

--- a/docs/public-functions.md
+++ b/docs/public-functions.md
@@ -91,6 +91,7 @@ See the [metadata workflow](metadata.md) for state and adapter semantics.
 | `Test-BackupConfigProfile` | Validate stored, imported, or draft profile data. |
 | `Export-BackupConfigProfile` | Export a user profile. |
 | `Import-BackupConfigProfile` | Import a profile with explicit conflict behavior. |
+| `Get-BackupWorkerCapability` | Inspect the hardware and encoder capabilities reported by backup workers. |
 | `Get-BackupAdapter` | Query registered backup adapters. |
 | `Register-BackupAdapter` | Register a trusted adapter implementation. |
 | `Remove-BackupAdapter` | Remove registered adapters. |

--- a/src/Private/Backup/RenderKit.BackupGpuDetectionService.ps1
+++ b/src/Private/Backup/RenderKit.BackupGpuDetectionService.ps1
@@ -155,7 +155,7 @@ function Test-BackupFfmpegEncoderCapability {
             '-hide_banner',
             '-loglevel', 'error',
             '-f', 'lavfi',
-            '-i', 'color=c=black:s=64x64:d=0.1',
+            '-i', 'color=c=black:s=640x360:d=0.1',
             '-frames:v', '1',
             '-an',
             '-c:v', $EncoderName,

--- a/src/Private/Backup/RenderKit.BackupGpuDetectionService.ps1
+++ b/src/Private/Backup/RenderKit.BackupGpuDetectionService.ps1
@@ -134,6 +134,88 @@ function Get-BackupFfmpegEncoderNameList {
     }
 }
 
+function Test-BackupFfmpegEncoderCapability {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FfmpegPath,
+        [Parameter(Mandatory)]
+        [string]$EncoderName,
+        [ValidateRange(1, 60)]
+        [int]$TimeoutSeconds = 15
+    )
+
+    $processInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $processInfo.FileName = $FfmpegPath
+    $processInfo.UseShellExecute = $false
+    $processInfo.RedirectStandardOutput = $true
+    $processInfo.RedirectStandardError = $true
+    $processInfo.CreateNoWindow = $true
+    foreach ($argument in @(
+            '-hide_banner',
+            '-loglevel', 'error',
+            '-f', 'lavfi',
+            '-i', 'color=c=black:s=64x64:d=0.1',
+            '-frames:v', '1',
+            '-an',
+            '-c:v', $EncoderName,
+            '-f', 'null',
+            '-')) {
+        $processInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $processInfo
+    try {
+        [void]$process.Start()
+        $standardOutput = $process.StandardOutput.ReadToEndAsync()
+        $standardError = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+            $process.Kill($true)
+            $process.WaitForExit()
+            return [PSCustomObject]@{
+                encoderName = $EncoderName
+                usable = $false
+                exitCode = $null
+                reason = 'ProbeTimedOut'
+                error = "Encoder probe exceeded $TimeoutSeconds second(s)."
+            }
+        }
+
+        $outputText = $standardOutput.GetAwaiter().GetResult()
+        $errorText = $standardError.GetAwaiter().GetResult()
+        return [PSCustomObject]@{
+            encoderName = $EncoderName
+            usable = $process.ExitCode -eq 0
+            exitCode = [int]$process.ExitCode
+            reason = if ($process.ExitCode -eq 0) {
+                'ProbeSucceeded'
+            }
+            else {
+                'ProbeFailed'
+            }
+            error = if ([string]::IsNullOrWhiteSpace($errorText)) {
+                $outputText
+            }
+            else {
+                $errorText
+            }
+        }
+    }
+    catch {
+        return [PSCustomObject]@{
+            encoderName = $EncoderName
+            usable = $false
+            exitCode = $null
+            reason = 'ProbeFailed'
+            error = $_.Exception.Message
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
 function Get-BackupVideoControllerNameList {
     [CmdletBinding()]
     param()
@@ -190,6 +272,7 @@ function New-BackupGpuCapabilityReport {
         [ValidateRange(1, 8760)]
         [int]$CacheTtlHours = 168,
         [string]$Source = 'Provided',
+        [hashtable]$EncoderProbeResults,
         [switch]$RunBenchmark
     )
 
@@ -226,12 +309,32 @@ function New-BackupGpuCapabilityReport {
         foreach ($codec in @('H264', 'H265', 'AV1')) {
             $encoder = [string](Get-BackupGpuObjectValue -InputObject $definition.encoders -Name $codec)
             $ffmpegSupported = $normalizedEncoderNames -contains $encoder.ToLowerInvariant()
+            $probeKnown = $null -ne $EncoderProbeResults -and
+                $EncoderProbeResults.ContainsKey($encoder)
+            $probeSucceeded = $probeKnown -and
+                [bool]$EncoderProbeResults[$encoder].usable
             $codecCapabilities[$codec] = [PSCustomObject]@{
                 codec          = $codec
                 encoderName    = $encoder
                 ffmpegSupported = [bool]$ffmpegSupported
                 hardwareDetected = [bool]$hardwareDetected
-                usableForAuto = [bool]($ffmpegSupported -and $hardwareDetected)
+                probeKnown     = [bool]$probeKnown
+                probeSucceeded = if ($probeKnown) {
+                    [bool]$probeSucceeded
+                }
+                else {
+                    $null
+                }
+                probeReason    = if ($probeKnown) {
+                    [string]$EncoderProbeResults[$encoder].reason
+                }
+                else {
+                    $null
+                }
+                usableForAuto = [bool](
+                    $ffmpegSupported -and
+                    $hardwareDetected -and
+                    (-not $RunBenchmark -or $probeSucceeded))
             }
         }
 
@@ -289,7 +392,7 @@ function New-BackupGpuCapabilityReport {
 
     $detectedAtUtc = (Get-Date).ToUniversalTime()
     return [PSCustomObject]@{
-        schemaVersion = '1.0'
+        schemaVersion = '1.1'
         source        = $Source
         detectedAtUtc = $detectedAtUtc.ToString('o')
         expiresAtUtc  = $detectedAtUtc.AddHours($CacheTtlHours).ToString('o')
@@ -307,9 +410,15 @@ function New-BackupGpuCapabilityReport {
         recommendations = [PSCustomObject]$recommendations
         benchmark     = [PSCustomObject]@{
             requested = [bool]$RunBenchmark
-            state     = if ($RunBenchmark) { 'Planned' } else { 'NotRun' }
+            state     = if ($RunBenchmark) { 'Completed' } else { 'NotRun' }
             mode      = 'CapabilityCacheMicroBenchmark'
-            reason    = if ($RunBenchmark) { 'Benchmark can be run by a worker without blocking planning.' } else { 'Capability detection does not run encode benchmarks by default.' }
+            reason    = if ($RunBenchmark) { 'Hardware encoders were validated with a one-frame capability probe.' } else { 'Capability detection did not run encode probes.' }
+            results   = if ($null -ne $EncoderProbeResults) {
+                [PSCustomObject]$EncoderProbeResults
+            }
+            else {
+                [PSCustomObject]@{}
+            }
         }
         cache         = [PSCustomObject]@{
             enabled  = $true
@@ -373,6 +482,9 @@ function Read-BackupGpuCapabilityCache {
     try {
         $report = Get-Content -LiteralPath $Path -Raw -ErrorAction Stop |
             ConvertFrom-Json -ErrorAction Stop
+        if ([string]$report.schemaVersion -ne '1.1') {
+            return $null
+        }
         $expiresAtText = [string](Get-BackupGpuObjectValue -InputObject $report -Name 'expiresAtUtc')
         $expiresAt = [datetime]::MinValue
         $isExpired = -not [datetime]::TryParse(
@@ -429,6 +541,39 @@ function Get-BackupGpuCapabilityReport {
         }
     )
 
+    $detectedReport = New-BackupGpuCapabilityReport `
+        -EncoderNames @($encoderNames) `
+        -VideoControllerNames @($controllerNames) `
+        -DetectedCommands @($detectedCommands) `
+        -FfmpegPath $ffmpegPath `
+        -CachePath $cachePath `
+        -CacheTtlHours $CacheTtlHours `
+        -Source 'Live'
+
+    $probeResults = @{}
+    if (-not [string]::IsNullOrWhiteSpace($ffmpegPath)) {
+        foreach ($provider in @($detectedReport.providers |
+                Where-Object { [bool]$_.hardwareDetected })) {
+            foreach ($codec in @('H264', 'H265', 'AV1')) {
+                $capability = Get-BackupGpuObjectValue `
+                    -InputObject $provider.codecCapabilities `
+                    -Name $codec
+                if (-not $capability -or
+                    -not [bool]$capability.ffmpegSupported) {
+                    continue
+                }
+                $encoderName = [string]$capability.encoderName
+                if ($probeResults.ContainsKey($encoderName)) {
+                    continue
+                }
+                $probeResults[$encoderName] =
+                    Test-BackupFfmpegEncoderCapability `
+                        -FfmpegPath $ffmpegPath `
+                        -EncoderName $encoderName
+            }
+        }
+    }
+
     $report = New-BackupGpuCapabilityReport `
         -EncoderNames @($encoderNames) `
         -VideoControllerNames @($controllerNames) `
@@ -437,7 +582,8 @@ function Get-BackupGpuCapabilityReport {
         -CachePath $cachePath `
         -CacheTtlHours $CacheTtlHours `
         -Source 'Live' `
-        -RunBenchmark:$RunBenchmark
+        -EncoderProbeResults $probeResults `
+        -RunBenchmark
 
     if (-not $SkipCacheWrite) {
         Save-BackupGpuCapabilityCache -Report $report -Path $cachePath | Out-Null

--- a/src/Private/Backup/RenderKit.BackupWorkerCapabilityService.ps1
+++ b/src/Private/Backup/RenderKit.BackupWorkerCapabilityService.ps1
@@ -1,0 +1,212 @@
+function Get-BackupWorkerCapabilitySnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkerId,
+        [switch]$Refresh
+    )
+
+    $gpu = Get-BackupGpuCapabilityReport -Refresh:$Refresh
+    $encoderNames = @(
+        @($gpu.ffmpeg.encoderNames) |
+            ForEach-Object { ([string]$_).ToLowerInvariant() }
+    )
+    $cpuCodecs = @(
+        foreach ($codec in @('H264', 'H265', 'AV1')) {
+            $encoderName = Get-BackupCpuEncoderName -VideoCodec $codec
+            if ($encoderNames -contains $encoderName.ToLowerInvariant()) {
+                $codec
+            }
+        }
+    )
+    $devices = New-Object System.Collections.Generic.List[object]
+    $devices.Add([PSCustomObject]@{
+            id               = 'CPU'
+            displayName      = 'CPU'
+            hardwareDetected = $true
+            codecs           = @($cpuCodecs)
+            encoderNames     = [PSCustomObject]@{
+                H264 = Get-BackupCpuEncoderName -VideoCodec H264
+                H265 = Get-BackupCpuEncoderName -VideoCodec H265
+                AV1  = Get-BackupCpuEncoderName -VideoCodec AV1
+            }
+        })
+    foreach ($provider in @($gpu.providers)) {
+        $devices.Add([PSCustomObject]@{
+                id               = [string]$provider.id
+                displayName      = [string]$provider.displayName
+                hardwareDetected = [bool]$provider.hardwareDetected
+                codecs           = @($provider.usableCodecs)
+                encoderNames     = [PSCustomObject]@{
+                    H264 = [string]$provider.codecCapabilities.H264.encoderName
+                    H265 = [string]$provider.codecCapabilities.H265.encoderName
+                    AV1  = [string]$provider.codecCapabilities.AV1.encoderName
+                }
+            })
+    }
+
+    return [PSCustomObject]@{
+        schemaVersion = '1.0'
+        workerId       = $WorkerId
+        machine        = [Environment]::MachineName
+        online         = $true
+        status         = 'Ready'
+        detectedAtUtc  = [string]$gpu.detectedAtUtc
+        expiresAtUtc   = [string]$gpu.expiresAtUtc
+        source         = [string]$gpu.source
+        runtime        = [PSCustomObject]@{
+            platform       = Get-RenderKitPlatform
+            processorCount = [Environment]::ProcessorCount
+            powerShell     = $PSVersionTable.PSVersion.ToString()
+        }
+        ffmpeg         = [PSCustomObject]@{
+            available = [bool]$gpu.ffmpeg.available
+            path      = [string]$gpu.ffmpeg.path
+        }
+        devices        = @($devices.ToArray())
+    }
+}
+
+function Test-BackupProfileWorkerCompatibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Settings,
+        [object[]]$WorkerCapability = @()
+    )
+
+    $resolvedCodec = Resolve-BackupVideoCodec `
+        -VideoCodec ([string]$Settings.VideoCodec) `
+        -CompressionPreset ([string]$Settings.CompressionPreset)
+    $requiresEncoding = [string]$Settings.CompressionMode -notin @(
+        'ArchiveOnly',
+        'CopyOnly'
+    )
+    $requestedDevice = [string]$Settings.EncoderDevice
+    $workers = New-Object System.Collections.Generic.List[object]
+
+    foreach ($capability in @($WorkerCapability)) {
+        $online = if (
+            $capability.PSObject.Properties.Name -contains 'online'
+        ) {
+            [bool]$capability.online
+        }
+        else {
+            $true
+        }
+        $compatible = $false
+        $resolvedDevice = $null
+        $reason = 'NoCompatibleEncoder'
+        $usesCpuFallback = $false
+
+        if (-not $online) {
+            $reason = 'WorkerOffline'
+        }
+        elseif (-not $requiresEncoding) {
+            $compatible = $true
+            $reason = 'NoEncodingRequired'
+        }
+        else {
+            $devices = @($capability.devices)
+            if ($requestedDevice -eq 'Auto') {
+                $hardware = @(
+                    $devices |
+                        Where-Object {
+                            [string]$_.id -ne 'CPU' -and
+                            @($_.codecs) -contains $resolvedCodec
+                        } |
+                        Select-Object -First 1
+                )
+                $cpu = @(
+                    $devices |
+                        Where-Object {
+                            [string]$_.id -eq 'CPU' -and
+                            @($_.codecs) -contains $resolvedCodec
+                        } |
+                        Select-Object -First 1
+                )
+                if ($hardware.Count -gt 0) {
+                    $compatible = $true
+                    $resolvedDevice = [string]$hardware[0].id
+                    $reason = 'HardwareEncoderAvailable'
+                }
+                elseif ($cpu.Count -gt 0) {
+                    $compatible = $true
+                    $resolvedDevice = 'CPU'
+                    $reason = 'CpuFallback'
+                    $usesCpuFallback = $true
+                }
+            }
+            else {
+                $requested = @(
+                    $devices |
+                        Where-Object {
+                            [string]$_.id -eq $requestedDevice -and
+                            @($_.codecs) -contains $resolvedCodec
+                        } |
+                        Select-Object -First 1
+                )
+                if ($requested.Count -gt 0) {
+                    $compatible = $true
+                    $resolvedDevice = $requestedDevice
+                    $reason = if ($requestedDevice -eq 'CPU') {
+                        'CpuEncoderAvailable'
+                    }
+                    else {
+                        'HardwareEncoderAvailable'
+                    }
+                }
+                else {
+                    $reason = 'RequestedDeviceUnavailable'
+                }
+            }
+        }
+
+        $workers.Add([PSCustomObject]@{
+                workerId       = [string]$capability.workerId
+                machine        = [string]$capability.machine
+                online         = $online
+                compatible     = $compatible
+                resolvedCodec  = $resolvedCodec
+                requestedDevice = $requestedDevice
+                resolvedDevice = $resolvedDevice
+                usesCpuFallback = $usesCpuFallback
+                reason         = $reason
+            })
+    }
+
+    $workerArray = @($workers.ToArray())
+    $onlineWorkers = @($workerArray | Where-Object { $_.online })
+    $compatibleWorkers = @(
+        $onlineWorkers | Where-Object { $_.compatible }
+    )
+    $fallbackWorkers = @(
+        $compatibleWorkers | Where-Object { $_.usesCpuFallback }
+    )
+    $status = if ($compatibleWorkers.Count -eq 0) {
+        'Unavailable'
+    }
+    elseif (
+        $compatibleWorkers.Count -lt $onlineWorkers.Count -or
+        $fallbackWorkers.Count -gt 0
+    ) {
+        'Degraded'
+    }
+    else {
+        'Available'
+    }
+
+    return [PSCustomObject]@{
+        schemaVersion       = '1.0'
+        status              = $status
+        isExecutable        = $compatibleWorkers.Count -gt 0
+        requiresEncoding    = $requiresEncoding
+        requestedCodec      = [string]$Settings.VideoCodec
+        resolvedCodec       = $resolvedCodec
+        requestedDevice     = $requestedDevice
+        compatibleWorkerIds = @(
+            $compatibleWorkers | ForEach-Object { [string]$_.workerId }
+        )
+        workers             = $workerArray
+    }
+}

--- a/src/Private/Job/RenderKit.WorkerDaemonService.ps1
+++ b/src/Private/Job/RenderKit.WorkerDaemonService.ps1
@@ -95,6 +95,7 @@ function New-RenderKitWorkerState {
         [string[]]$RecoveredJobIds = @(),
         [object]$LastTick,
         [object]$LastError,
+        [object]$Capabilities,
         [string]$StartedAtUtc
     )
 
@@ -123,6 +124,7 @@ function New-RenderKitWorkerState {
         recoveredJobIds = @($RecoveredJobIds)
         lastTick        = $LastTick
         lastError       = $LastError
+        capabilities    = $Capabilities
         logPath         = $LogPath
     }
 }
@@ -278,6 +280,9 @@ function Register-RenderKitWorkerCrashIfNeeded {
         -ProcessedCount ([int]$previous.processedCount) `
         -IdleTickCount ([int]$previous.idleTickCount) `
         -RecoveredJobIds @($previous.recoveredJobIds) `
+        -Capabilities $(if (
+            $previous.PSObject.Properties.Name -contains 'capabilities'
+        ) { $previous.capabilities } else { $null }) `
         -LastError ([PSCustomObject]@{
             message       = 'Previous worker process is no longer alive.'
             previousPid   = $previous.processId
@@ -418,6 +423,9 @@ function Get-RenderKitWorkerStatusSnapshot {
         recoveredJobIds = @($State.recoveredJobIds)
         lastTick       = $State.lastTick
         lastError      = $State.lastError
+        capabilities   = if (
+            $State.PSObject.Properties.Name -contains 'capabilities'
+        ) { $State.capabilities } else { $null }
         statePath      = Get-RenderKitWorkerStatePath -WorkerId ([string]$State.workerId)
         logPath        = $logPath
         logs           = if ($IncludeLogs) { @(Read-RenderKitWorkerLogTail -LogPath $logPath -Tail $Tail) } else { @() }
@@ -450,11 +458,22 @@ function Invoke-RenderKitLocalWorkerLoop {
         -JobType $JobType `
         -QueueName $QueueName `
         -LogPath $LogPath
+    $capabilityCommand = Get-Command `
+        -Name Get-BackupWorkerCapabilitySnapshot `
+        -CommandType Function `
+        -ErrorAction SilentlyContinue
+    $workerCapabilities = if ($capabilityCommand) {
+        Get-BackupWorkerCapabilitySnapshot -WorkerId $normalizedWorkerId
+    }
+    else {
+        $null
+    }
     $state = New-RenderKitWorkerState `
         -WorkerId $normalizedWorkerId `
         -JobType $JobType `
         -QueueName $QueueName `
         -LogPath $LogPath `
+        -Capabilities $workerCapabilities `
         -Status Running
     Save-RenderKitWorkerState -State $state | Out-Null
     Write-RenderKitWorkerLogEntry `
@@ -511,6 +530,7 @@ function Invoke-RenderKitLocalWorkerLoop {
                 -IdleTickCount $idleTickCount `
                 -RecoveredJobIds @($recoveredJobIds.ToArray()) `
                 -LastTick $tick `
+                -Capabilities $workerCapabilities `
                 -StartedAtUtc ([string]$state.startedAtUtc)
             Save-RenderKitWorkerState -State $state | Out-Null
 

--- a/src/Private/Project/RenderKit.ProjectExportService.ps1
+++ b/src/Private/Project/RenderKit.ProjectExportService.ps1
@@ -3,6 +3,85 @@ if ($PSVersionTable.PSVersion.Major -le 5) {
     Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
 } # Powershell 5.1 Support guard. T_T 
 
+function Get-RenderKitProjectExportFormat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('ManifestOnly', 'SelfContained')]
+        [string]$Mode
+    )
+
+    if ($null -eq $script:RenderKitFileFormatCatalog) {
+        $catalogPath = Join-Path `
+            -Path $script:RenderKitModuleRoot `
+            -ChildPath 'src/Resources/FileFormats/RenderKit.FileFormats.json'
+        if (-not (Test-Path -LiteralPath $catalogPath -PathType Leaf)) {
+            throw "RenderKit file format catalog '$catalogPath' was not found."
+        }
+        $script:RenderKitFileFormatCatalog = Get-Content `
+            -LiteralPath $catalogPath `
+            -Raw `
+            -Encoding UTF8 |
+            ConvertFrom-Json
+    }
+
+    $format = @($script:RenderKitFileFormatCatalog.formats |
+        Where-Object { [string]$_.exportMode -eq $Mode } |
+        Select-Object -First 1)
+    if ($format.Count -eq 0 -or
+        [string]::IsNullOrWhiteSpace([string]$format[0].extension)) {
+        throw "No RenderKit file format is registered for export mode '$Mode'."
+    }
+    return $format[0]
+}
+
+function Resolve-RenderKitProjectExportDestination {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$DestinationPath,
+        [Parameter(Mandatory)]
+        [ValidateSet('ManifestOnly', 'SelfContained')]
+        [string]$Mode
+    )
+
+    $format = Get-RenderKitProjectExportFormat -Mode $Mode
+    $requiredExtension = [string]$format.extension
+    $destinationIsDirectory = Test-Path `
+        -LiteralPath $DestinationPath `
+        -PathType Container
+    $trimmedDestination = $DestinationPath.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    if ($destinationIsDirectory -or
+        $trimmedDestination.Length -ne $DestinationPath.Length) {
+        $destinationDirectory = if ($destinationIsDirectory) {
+            (Resolve-Path `
+                -LiteralPath $DestinationPath `
+                -ErrorAction Stop).ProviderPath
+        }
+        else {
+            [System.IO.Path]::GetFullPath($trimmedDestination)
+        }
+        return Join-Path `
+            -Path $destinationDirectory `
+            -ChildPath ("{0}{1}" -f (
+                    Split-Path -Path $ProjectRoot -Leaf
+                ), $requiredExtension)
+    }
+
+    if ($DestinationPath.EndsWith(
+            $requiredExtension,
+            [System.StringComparison]::OrdinalIgnoreCase)) {
+        return '{0}{1}' -f $DestinationPath.Substring(
+            0,
+            $DestinationPath.Length - $requiredExtension.Length
+        ), $requiredExtension
+    }
+    return "$DestinationPath$requiredExtension"
+}
+
 function ConvertTo-RenderKitProjectRelativePath {
     [CmdletBinding()]
     param(

--- a/src/Public/Export-Project.ps1
+++ b/src/Public/Export-Project.ps1
@@ -26,30 +26,15 @@ Exports a RenderKit project manifest or self-contained project package.
         throw "Project root '$ProjectRoot' is not a directory."
     }
 
-    $destinationIsDirectory = Test-Path -LiteralPath $DestinationPath -PathType Container
-    $trimmedDestination = $DestinationPath.TrimEnd(
-        [System.IO.Path]::DirectorySeparatorChar,
-        [System.IO.Path]::AltDirectorySeparatorChar
-    )
-    if ($destinationIsDirectory -or $trimmedDestination.Length -ne $DestinationPath.Length) {
-        $destinationDirectory = if ($destinationIsDirectory) {
-            (Resolve-Path -LiteralPath $DestinationPath -ErrorAction Stop).ProviderPath
-        }
-        else {
-            [System.IO.Path]::GetFullPath($trimmedDestination)
-        }
-        $destinationExtension = if ($Mode -eq 'SelfContained') { '.rkitpkg' } else { '.rkit' }
-        $DestinationPath = Join-Path `
-            -Path $destinationDirectory `
-            -ChildPath ("{0}{1}" -f (Split-Path -Path $resolvedProjectRoot -Leaf), $destinationExtension)
-    }
-    
-    $extension = [System.IO.Path]::GetExtension($DestinationPath).ToLowerInvariant()
-    if ($Mode -eq 'ManifestOnly' -and $extension -ne '.rkit') {
-        Write-RenderKitLog -Level Warning -Message "ManifestOnly exports should use the .rkit extension."
-    }
-    if ($Mode -eq 'SelfContained' -and $extension -ne '.rkitpkg') {
-        Write-RenderKitLog -Level Warning -Message "SelfContained exports should use the .rkitpkg extension."
+    $requestedDestinationPath = $DestinationPath
+    $DestinationPath = Resolve-RenderKitProjectExportDestination `
+        -ProjectRoot $resolvedProjectRoot `
+        -DestinationPath $DestinationPath `
+        -Mode $Mode
+    if ($DestinationPath -cne $requestedDestinationPath) {
+        Write-RenderKitLog `
+            -Level Info `
+            -Message "Normalized project export destination to '$DestinationPath'."
     }
 
     if ($PSCmdlet.ShouldProcess($resolvedProjectRoot, "Export RenderKit project to '$DestinationPath'")) {

--- a/src/Public/Get-BackupWorkerCapability.ps1
+++ b/src/Public/Get-BackupWorkerCapability.ps1
@@ -1,0 +1,60 @@
+Register-RenderKitFunction 'Get-BackupWorkerCapability'
+function Get-BackupWorkerCapability {
+    <#
+.SYNOPSIS
+Returns execution capabilities for local and registered backup workers.
+
+.DESCRIPTION
+Each worker reports its own encoder capabilities. The returned array is
+designed for heterogeneous worker pools and includes offline registrations.
+#>
+    [CmdletBinding()]
+    param(
+        [string[]]$WorkerId,
+        [switch]$Refresh,
+        [switch]$OnlineOnly
+    )
+
+    $capabilities = [ordered]@{}
+    foreach ($state in @(Get-RenderKitWorkerStateList)) {
+        if (-not $state.capabilities -or
+            [string]::IsNullOrWhiteSpace([string]$state.workerId)) {
+            continue
+        }
+        $snapshot = $state.capabilities
+        $online = [string]$state.status -in @('Starting', 'Running', 'Idle') -and
+            (Test-RenderKitWorkerProcessAlive `
+                -ProcessId ([int]$state.processId) `
+                -MachineName ([string]$state.machine))
+        $snapshot | Add-Member `
+            -NotePropertyName online `
+            -NotePropertyValue ([bool]$online) `
+            -Force
+        $snapshot | Add-Member `
+            -NotePropertyName status `
+            -NotePropertyValue ([string]$state.status) `
+            -Force
+        $capabilities[[string]$state.workerId] = $snapshot
+    }
+
+    $localWorkerId = 'local-{0}' -f (
+        ConvertTo-RenderKitWorkerSafeName `
+            -Value ([Environment]::MachineName.ToLowerInvariant())
+    )
+    $capabilities[$localWorkerId] = Get-BackupWorkerCapabilitySnapshot `
+        -WorkerId $localWorkerId `
+        -Refresh:$Refresh
+
+    $result = @($capabilities.Values)
+    if ($WorkerId) {
+        $requested = @($WorkerId | ForEach-Object { [string]$_ })
+        $result = @(
+            $result |
+                Where-Object { $requested -contains [string]$_.workerId }
+        )
+    }
+    if ($OnlineOnly) {
+        $result = @($result | Where-Object { [bool]$_.online })
+    }
+    return @($result | Sort-Object workerId)
+}

--- a/src/Public/Start-RenderKitJobWorker.ps1
+++ b/src/Public/Start-RenderKitJobWorker.ps1
@@ -82,6 +82,8 @@ function Start-RenderKitJobWorker {
             -JobType $JobType `
             -QueueName $QueueName `
             -LogPath $LogPath `
+            -Capabilities (Get-BackupWorkerCapabilitySnapshot `
+                -WorkerId $normalizedWorkerId) `
             -Status Starting
         $state.processId = [int]$process.Id
         Save-RenderKitWorkerState -State $state | Out-Null

--- a/src/Public/Test-BackupConfigProfile.ps1
+++ b/src/Public/Test-BackupConfigProfile.ps1
@@ -18,7 +18,9 @@ Validates a built-in, stored, imported, or in-memory backup profile.
         [hashtable]$Settings = @{},
         [Parameter(ParameterSetName = 'Draft')]
         [string]$DraftName = 'studio-draft',
-        [switch]$CheckAdapters
+        [switch]$CheckAdapters,
+        [switch]$CheckHardware,
+        [object[]]$WorkerCapability
     )
 
     process {
@@ -54,17 +56,34 @@ Validates a built-in, stored, imported, or in-memory backup profile.
             $settingsValidation = Test-BackupConfigProfileSettings `
                 -Settings $profile.settings `
                 -CheckAdapters:$CheckAdapters
+            $executionCompatibility = if (
+                $CheckHardware -and $settingsValidation.normalizedSettings
+            ) {
+                $capabilities = if ($WorkerCapability) {
+                    @($WorkerCapability)
+                }
+                else {
+                    @(Get-BackupWorkerCapability)
+                }
+                Test-BackupProfileWorkerCompatibility `
+                    -Settings $settingsValidation.normalizedSettings `
+                    -WorkerCapability $capabilities
+            }
+            else {
+                $null
+            }
             return [PSCustomObject]@{
-                Name              = [string]$profile.name
-                Source            = 'BuiltIn'
-                Path              = $null
-                IsValid           = [bool]$settingsValidation.isValid
-                SchemaVersion     = [string]$profile.schemaVersion
-                ProfileVersion    = [string]$profile.profileVersion
-                Compatibility     = 'Current'
-                Errors            = @($settingsValidation.errors)
-                Warnings          = @($settingsValidation.warnings)
-                EffectiveSettings = $settingsValidation.normalizedSettings
+                Name                   = [string]$profile.name
+                Source                 = 'BuiltIn'
+                Path                   = $null
+                IsValid                = [bool]$settingsValidation.isValid
+                SchemaVersion          = [string]$profile.schemaVersion
+                ProfileVersion         = [string]$profile.profileVersion
+                Compatibility          = 'Current'
+                ExecutionCompatibility = $executionCompatibility
+                Errors                 = @($settingsValidation.errors)
+                Warnings               = @($settingsValidation.warnings)
+                EffectiveSettings      = $settingsValidation.normalizedSettings
             }
         }
 
@@ -73,31 +92,49 @@ Validates a built-in, stored, imported, or in-memory backup profile.
             $validation = Test-BackupConfigProfileDocumentDetailed `
                 -Profile $currentProfile `
                 -CheckAdapters:$CheckAdapters
+            $executionCompatibility = if (
+                $CheckHardware -and $validation.normalizedSettings
+            ) {
+                $capabilities = if ($WorkerCapability) {
+                    @($WorkerCapability)
+                }
+                else {
+                    @(Get-BackupWorkerCapability)
+                }
+                Test-BackupProfileWorkerCompatibility `
+                    -Settings $validation.normalizedSettings `
+                    -WorkerCapability $capabilities
+            }
+            else {
+                $null
+            }
             return [PSCustomObject]@{
-                Name              = [string]$currentProfile.name
-                Source            = $source
-                Path              = $sourcePath
-                IsValid           = [bool]$validation.isValid
-                SchemaVersion     = [string]$currentProfile.schemaVersion
-                ProfileVersion    = [string]$currentProfile.profileVersion
-                Compatibility     = if ($validation.compatibility) { [string]$validation.compatibility.Status } else { 'Unknown' }
-                Errors            = @($validation.errors)
-                Warnings          = @($validation.warnings)
-                EffectiveSettings = $validation.normalizedSettings
+                Name                   = [string]$currentProfile.name
+                Source                 = $source
+                Path                   = $sourcePath
+                IsValid                = [bool]$validation.isValid
+                SchemaVersion          = [string]$currentProfile.schemaVersion
+                ProfileVersion         = [string]$currentProfile.profileVersion
+                Compatibility          = if ($validation.compatibility) { [string]$validation.compatibility.Status } else { 'Unknown' }
+                ExecutionCompatibility = $executionCompatibility
+                Errors                 = @($validation.errors)
+                Warnings               = @($validation.warnings)
+                EffectiveSettings      = $validation.normalizedSettings
             }
         }
         catch {
             return [PSCustomObject]@{
-                Name              = if ($profile) { [string]$profile.name } else { $null }
-                Source            = $source
-                Path              = $sourcePath
-                IsValid           = $false
-                SchemaVersion     = if ($profile) { [string]$profile.schemaVersion } else { $null }
-                ProfileVersion    = if ($profile) { [string]$profile.profileVersion } else { $null }
-                Compatibility     = 'Invalid'
-                Errors            = @($_.Exception.Message)
-                Warnings          = @()
-                EffectiveSettings = $null
+                Name                   = if ($profile) { [string]$profile.name } else { $null }
+                Source                 = $source
+                Path                   = $sourcePath
+                IsValid                = $false
+                SchemaVersion          = if ($profile) { [string]$profile.schemaVersion } else { $null }
+                ProfileVersion         = if ($profile) { [string]$profile.profileVersion } else { $null }
+                Compatibility          = 'Invalid'
+                ExecutionCompatibility = $null
+                Errors                 = @($_.Exception.Message)
+                Warnings               = @()
+                EffectiveSettings      = $null
             }
         }
     }

--- a/src/Resources/FileFormats/RenderKit.FileFormats.json
+++ b/src/Resources/FileFormats/RenderKit.FileFormats.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "formats": [
+    {
+      "id": "project-manifest",
+      "displayName": "RenderKit Project Manifest",
+      "extension": ".rkit",
+      "exportMode": "ManifestOnly",
+      "container": "zip",
+      "mediaType": "application/vnd.renderkit.project+zip",
+      "fallbackMediaType": "application/zip",
+      "uniformTypeIdentifier": "com.conceptmarton.renderkit.project-manifest",
+      "windowsProgId": "RenderKit.ProjectManifest"
+    },
+    {
+      "id": "project-package",
+      "displayName": "RenderKit Project Package",
+      "extension": ".rkitpkg",
+      "exportMode": "SelfContained",
+      "container": "zip",
+      "mediaType": "application/vnd.renderkit.project-package+zip",
+      "fallbackMediaType": "application/zip",
+      "uniformTypeIdentifier": "com.conceptmarton.renderkit.project-package",
+      "windowsProgId": "RenderKit.ProjectPackage"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Hardware encoders are checked with a small one-frame encode before automatic selection.
- Only encoders executable on the actual GPU are considered `usableForAuto`.
- The capability cache schema was bumped to 1.1 to discard old, false-positive entries.
- If e.g. `av1_nvenc` exists in FFmpeg but the GPU lacks AV1 support, the engine safely falls back to the CPU encoder.

## Cause

The previous detection only combined the FFmpeg encoder catalog with the GPU vendor. A GTX 1080 Ti was therefore whitelisted for `av1_nvenc`, even though FFmpeg reports `No capable devices found` at startup.

## Validation

- Live test on the affected GTX 1080 Ti: AV1 -> CPU / `libsvtav1`
- Focused Pester test for the RS-1129 fallback
- `git diff --check`
