### PR TITLE
RS-1204: Enforce canonical project export extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 # Changelog
+
+## 1.1.3 - 2026-07-31
+
+### Added
+
+- Added RS-798/RS-799 worker capability discovery for local and registered
+  backup workers, including per-worker CPU, GPU, FFmpeg, and encoder support.
+- Added per-worker backup-profile execution results with eligible worker IDs,
+  compatibility states, and CPU-fallback reporting without preventing users
+  from storing structurally valid custom profiles.
+- Added RS-1204 machine-readable and documented RenderKit file-format
+  definitions for the ZIP-based `.rkit` and `.rkitpkg` project archives.
+
+### Changed
+
+- RS-1204 project exports now always append the canonical `.rkit` or
+  `.rkitpkg` extension when another extension is requested, normalize canonical
+  extension casing, and continue returning the effective output path.
+- RS-798/RS-799 hardware validation now evaluates every available worker
+  independently and preserves offline worker registrations for heterogeneous
+  future worker pools.
+
+### Fixed
+
+- Fixed RS-1129 automatic encoder selection treating an FFmpeg encoder as
+  usable when the installed GPU cannot execute it. Hardware encoders are now
+  probed with a real one-frame encode at supported dimensions and safely fall
+  back to a compatible CPU encoder.
+
 ## 1.1.2 - 2026-07-23
 
 ### Added

--- a/Tests/Public/Export-Project.Tests.ps1
+++ b/Tests/Public/Export-Project.Tests.ps1
@@ -20,6 +20,7 @@ BeforeAll {
 
 Describe 'Export-Project' {
     BeforeEach {
+        $script:RenderKitFileFormatCatalog = $null
         $script:RenderKitArtifactVersionCatalog = $null
         $script:RenderKitArtifactMigrations = @{}
         $script:RenderKitModuleVersion = '0.0.0'
@@ -47,5 +48,84 @@ Describe 'Export-Project' {
         $expectedPath = Join-Path $destinationRoot 'ProjectA.rkit'
         $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
         Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'appends the canonical manifest extension to an arbitrary file extension' {
+        $projectRoot = Join-Path $TestDrive 'ProjectB'
+        $requestedPath = Join-Path $TestDrive 'exporttest.txt'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode ManifestOnly
+
+        $expectedPath = "$requestedPath.rkit"
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $requestedPath -PathType Leaf |
+            Should -BeFalse
+    }
+
+    It 'appends the canonical package extension for self-contained exports' {
+        $projectRoot = Join-Path $TestDrive 'ProjectC'
+        $requestedPath = Join-Path $TestDrive 'portable.zip'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode SelfContained
+
+        $expectedPath = "$requestedPath.rkitpkg"
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'normalizes the casing of an otherwise canonical extension' {
+        $projectRoot = Join-Path $TestDrive 'ProjectD'
+        $requestedPath = Join-Path $TestDrive 'manifest.RKIT'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode ManifestOnly
+
+        $expectedPath = Join-Path $TestDrive 'manifest.rkit'
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'writes both RenderKit project formats as readable zip archives' {
+        $projectRoot = Join-Path $TestDrive 'ProjectE'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        foreach ($mode in @('ManifestOnly', 'SelfContained')) {
+            $requestedPath = Join-Path $TestDrive $mode
+            $result = Export-Project `
+                -ProjectRoot $projectRoot `
+                -DestinationPath $requestedPath `
+                -Mode $mode
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($result.Path)
+            try {
+                $archive.GetEntry('project.xml') | Should -Not -BeNullOrEmpty
+            }
+            finally {
+                $archive.Dispose()
+            }
+        }
     }
 }

--- a/build/Test-RenderKitPackage.ps1
+++ b/build/Test-RenderKitPackage.ps1
@@ -34,6 +34,7 @@ try {
         'src/Resources/Metadata/ixml-field-map.json',
         'src/Resources/Metadata/iptc-field-map.json',
         'src/Resources/Metadata/matroska-field-map.json',
+        'src/Resources/FileFormats/RenderKit.FileFormats.json',
         'src/Resources/ThirdParty/MediaInfo/manifest.json',
         'src/Resources/ThirdParty/ExifTool/manifest.json',
         'src/Resources/ThirdParty/ExifTool/files.sha256',

--- a/docs/Export-Project.md
+++ b/docs/Export-Project.md
@@ -21,7 +21,7 @@ Export-Project -ProjectRoot <string> -DestinationPath <string> [-Mode <string>] 
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `-ProjectRoot` | `string` | Yes | – | Full path to the project directory. |
-| `-DestinationPath` | `string` | Yes | – | Destination file path for the manifest/package, or an existing destination directory. Directory destinations create `<ProjectRootName>.rkit` for `ManifestOnly` exports and `<ProjectRootName>.rkitpkg` for `SelfContained` exports. |
+| `-DestinationPath` | `string` | Yes | – | Destination file path for the manifest/package, or an existing destination directory. RenderKit always appends the canonical `.rkit` or `.rkitpkg` extension when it is missing or another extension was supplied. Directory destinations create `<ProjectRootName>.rkit` for `ManifestOnly` exports and `<ProjectRootName>.rkitpkg` for `SelfContained` exports. |
 | `-Mode` | `string` | No | `'ManifestOnly'` | Export mode. |
 | `-CompressionMethod` | `string` | No | `'Zip'` | Compression method. |
 | `-CompressionLevel` | `string` | No | `'Optimal'` | Compression level. |
@@ -36,6 +36,19 @@ Export-Project -ProjectRoot "D:\Projects\ClientA" -DestinationPath "E:\Transfer"
 ```
 
 Exports `D:\Projects\ClientA` to `E:\Transfer\ClientA.rkit`.
+
+If a non-RenderKit extension is supplied, it remains part of the base file
+name and the canonical extension is appended:
+
+```powershell
+Export-Project `
+  -ProjectRoot "D:\Projects\ClientA" `
+  -DestinationPath "E:\Transfer\ClientA.zip" `
+  -Mode SelfContained
+```
+
+This writes `E:\Transfer\ClientA.zip.rkitpkg`. Existing files at the originally
+requested non-RenderKit path are not overwritten.
 
 
 Before running the command, inspect its full help with `Get-Help Export-Project -Full`. For commands that support `ShouldProcess`, use `-WhatIf` before making production changes.

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1,0 +1,36 @@
+# RenderKit file formats
+
+RenderKit-owned portable artifacts use a RenderKit-specific extension. The
+extension identifies the domain artifact; its underlying serialization remains
+available to standard tooling.
+
+## Active project formats
+
+| Extension | Artifact | Container | Media type |
+| --- | --- | --- | --- |
+| `.rkit` | Project manifest and portable resources | ZIP | `application/vnd.renderkit.project+zip` |
+| `.rkitpkg` | Self-contained project package including project files | ZIP | `application/vnd.renderkit.project-package+zip` |
+
+Both formats are valid ZIP archives and contain `project.xml` at the archive
+root. Operating-system integration may therefore classify them as ZIP-based
+archives without changing their RenderKit-specific extension.
+
+The machine-readable format identifiers used by Core and packaging integrations
+are stored in `src/Resources/FileFormats/RenderKit.FileFormats.json`.
+
+## Reserved portable artifact extensions
+
+The following extensions are reserved for future or migrated portability
+commands. Reserving them does not change the internal JSON files used by the
+RenderKit runtime.
+
+| Extension | Intended artifact |
+| --- | --- |
+| `.rkittemplate` | Portable project or metadata template |
+| `.rkitmapping` | Portable media mapping |
+| `.rkitprofile` | Portable backup or workflow profile |
+| `.rkitmetadata` | Portable metadata export |
+| `.rkitjobs` | Portable job-history collection |
+
+RenderKit types remain part of a mapping. A separate type extension should only
+be introduced if types become independently versioned and portable artifacts.

--- a/src/Private/Project/RenderKit.ProjectExportService.ps1
+++ b/src/Private/Project/RenderKit.ProjectExportService.ps1
@@ -3,6 +3,85 @@ if ($PSVersionTable.PSVersion.Major -le 5) {
     Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
 } # Powershell 5.1 Support guard. T_T 
 
+function Get-RenderKitProjectExportFormat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('ManifestOnly', 'SelfContained')]
+        [string]$Mode
+    )
+
+    if ($null -eq $script:RenderKitFileFormatCatalog) {
+        $catalogPath = Join-Path `
+            -Path $script:RenderKitModuleRoot `
+            -ChildPath 'src/Resources/FileFormats/RenderKit.FileFormats.json'
+        if (-not (Test-Path -LiteralPath $catalogPath -PathType Leaf)) {
+            throw "RenderKit file format catalog '$catalogPath' was not found."
+        }
+        $script:RenderKitFileFormatCatalog = Get-Content `
+            -LiteralPath $catalogPath `
+            -Raw `
+            -Encoding UTF8 |
+            ConvertFrom-Json
+    }
+
+    $format = @($script:RenderKitFileFormatCatalog.formats |
+        Where-Object { [string]$_.exportMode -eq $Mode } |
+        Select-Object -First 1)
+    if ($format.Count -eq 0 -or
+        [string]::IsNullOrWhiteSpace([string]$format[0].extension)) {
+        throw "No RenderKit file format is registered for export mode '$Mode'."
+    }
+    return $format[0]
+}
+
+function Resolve-RenderKitProjectExportDestination {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$DestinationPath,
+        [Parameter(Mandatory)]
+        [ValidateSet('ManifestOnly', 'SelfContained')]
+        [string]$Mode
+    )
+
+    $format = Get-RenderKitProjectExportFormat -Mode $Mode
+    $requiredExtension = [string]$format.extension
+    $destinationIsDirectory = Test-Path `
+        -LiteralPath $DestinationPath `
+        -PathType Container
+    $trimmedDestination = $DestinationPath.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    if ($destinationIsDirectory -or
+        $trimmedDestination.Length -ne $DestinationPath.Length) {
+        $destinationDirectory = if ($destinationIsDirectory) {
+            (Resolve-Path `
+                -LiteralPath $DestinationPath `
+                -ErrorAction Stop).ProviderPath
+        }
+        else {
+            [System.IO.Path]::GetFullPath($trimmedDestination)
+        }
+        return Join-Path `
+            -Path $destinationDirectory `
+            -ChildPath ("{0}{1}" -f (
+                    Split-Path -Path $ProjectRoot -Leaf
+                ), $requiredExtension)
+    }
+
+    if ($DestinationPath.EndsWith(
+            $requiredExtension,
+            [System.StringComparison]::OrdinalIgnoreCase)) {
+        return '{0}{1}' -f $DestinationPath.Substring(
+            0,
+            $DestinationPath.Length - $requiredExtension.Length
+        ), $requiredExtension
+    }
+    return "$DestinationPath$requiredExtension"
+}
+
 function ConvertTo-RenderKitProjectRelativePath {
     [CmdletBinding()]
     param(

--- a/src/Public/Export-Project.ps1
+++ b/src/Public/Export-Project.ps1
@@ -26,30 +26,15 @@ Exports a RenderKit project manifest or self-contained project package.
         throw "Project root '$ProjectRoot' is not a directory."
     }
 
-    $destinationIsDirectory = Test-Path -LiteralPath $DestinationPath -PathType Container
-    $trimmedDestination = $DestinationPath.TrimEnd(
-        [System.IO.Path]::DirectorySeparatorChar,
-        [System.IO.Path]::AltDirectorySeparatorChar
-    )
-    if ($destinationIsDirectory -or $trimmedDestination.Length -ne $DestinationPath.Length) {
-        $destinationDirectory = if ($destinationIsDirectory) {
-            (Resolve-Path -LiteralPath $DestinationPath -ErrorAction Stop).ProviderPath
-        }
-        else {
-            [System.IO.Path]::GetFullPath($trimmedDestination)
-        }
-        $destinationExtension = if ($Mode -eq 'SelfContained') { '.rkitpkg' } else { '.rkit' }
-        $DestinationPath = Join-Path `
-            -Path $destinationDirectory `
-            -ChildPath ("{0}{1}" -f (Split-Path -Path $resolvedProjectRoot -Leaf), $destinationExtension)
-    }
-    
-    $extension = [System.IO.Path]::GetExtension($DestinationPath).ToLowerInvariant()
-    if ($Mode -eq 'ManifestOnly' -and $extension -ne '.rkit') {
-        Write-RenderKitLog -Level Warning -Message "ManifestOnly exports should use the .rkit extension."
-    }
-    if ($Mode -eq 'SelfContained' -and $extension -ne '.rkitpkg') {
-        Write-RenderKitLog -Level Warning -Message "SelfContained exports should use the .rkitpkg extension."
+    $requestedDestinationPath = $DestinationPath
+    $DestinationPath = Resolve-RenderKitProjectExportDestination `
+        -ProjectRoot $resolvedProjectRoot `
+        -DestinationPath $DestinationPath `
+        -Mode $Mode
+    if ($DestinationPath -cne $requestedDestinationPath) {
+        Write-RenderKitLog `
+            -Level Info `
+            -Message "Normalized project export destination to '$DestinationPath'."
     }
 
     if ($PSCmdlet.ShouldProcess($resolvedProjectRoot, "Export RenderKit project to '$DestinationPath'")) {

--- a/src/Resources/FileFormats/RenderKit.FileFormats.json
+++ b/src/Resources/FileFormats/RenderKit.FileFormats.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "formats": [
+    {
+      "id": "project-manifest",
+      "displayName": "RenderKit Project Manifest",
+      "extension": ".rkit",
+      "exportMode": "ManifestOnly",
+      "container": "zip",
+      "mediaType": "application/vnd.renderkit.project+zip",
+      "fallbackMediaType": "application/zip",
+      "uniformTypeIdentifier": "com.conceptmarton.renderkit.project-manifest",
+      "windowsProgId": "RenderKit.ProjectManifest"
+    },
+    {
+      "id": "project-package",
+      "displayName": "RenderKit Project Package",
+      "extension": ".rkitpkg",
+      "exportMode": "SelfContained",
+      "container": "zip",
+      "mediaType": "application/vnd.renderkit.project-package+zip",
+      "fallbackMediaType": "application/zip",
+      "uniformTypeIdentifier": "com.conceptmarton.renderkit.project-package",
+      "windowsProgId": "RenderKit.ProjectPackage"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- enforce `.rkit` for ManifestOnly project exports
- enforce `.rkitpkg` for SelfContained project exports
- append the canonical RenderKit extension when a user supplies another extension, preserving the original path
- normalize canonical extension casing without duplicating the extension
- introduce a packaged machine-readable file-format catalog for Core and operating-system integrations
- document active and reserved RenderKit artifact extensions

## Related work item

- RS-1204 — Prevent arbitrary project export extensions
- Prepares RS-1206 — Register RenderKit ZIP-based formats with Windows, macOS, and Linux
- Stacked on RenderKit Core PR #78 in stack #80

## Acceptance criteria

- [x] `exporttest.txt` becomes `exporttest.txt.rkit` for ManifestOnly exports.
- [x] SelfContained exports always end in `.rkitpkg`.
- [x] Existing files at the originally requested arbitrary path are not overwritten.
- [x] Correct extensions are not duplicated.
- [x] Both output formats remain readable ZIP archives containing `project.xml`.
- [x] Legacy misnamed archives remain importable for backward compatibility.

## Validation

- `Invoke-Pester -Path Tests/Public/Export-Project.Tests.ps1 -Output Detailed` — 5 passed
- `./build/Build-RenderKitPackage.ps1 -SkipPackage`
- `git diff --check`

## Risk and rollback

Callers that relied on arbitrary output extensions now receive a new path with the canonical suffix. The returned `Path` already exposes that normalized result. Revert this PR to restore warning-only behavior.