### PR TITLE
1.1.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '04:00'
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    target-branch: 1.1.3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,298 @@
+name: Maintain changelog
+
+on:
+  push:
+    branches:
+      - main
+      - '*.*.*'
+  pull_request:
+    branches:
+      - main
+      - '*.*.*'
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dependabot-ticket:
+    name: Dependabot YouTrack Ticket
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: windows-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: pwsh
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Create YouTrack ticket and update PR title
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          YT_BASE: ${{ vars.YT_BASE_URL }}
+          YT_TOKEN: ${{ secrets.YT_API_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ([string]::IsNullOrWhiteSpace($env:YT_BASE)) {
+            throw 'YouTrack base URL is missing. Configure the repository variable YT_BASE_URL, for example https://example.youtrack.cloud.'
+          }
+
+          if ($env:YT_BASE -match 'deine-instanz') {
+            throw 'YouTrack base URL still contains the placeholder deine-instanz. Configure the repository variable YT_BASE_URL.'
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:YT_TOKEN)) {
+            throw 'YouTrack token is missing. Configure YT_API_TOKEN as a Dependabot secret for Dependabot-triggered pull requests.'
+          }
+
+          $prTitleOutput = & gh pr view $env:PR_NUMBER `
+            --repo $env:GITHUB_REPOSITORY `
+            --json title `
+            --jq '.title' 2>&1
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to read pull request title: $($prTitleOutput | Out-String)"
+          }
+
+          $prTitle = ($prTitleOutput | Out-String).Trim()
+
+          if ($prTitle -match '(?<![A-Za-z0-9])RS-[0-9]+(?![A-Za-z0-9])') {
+            Write-Host 'YouTrack ticket is already present in the current PR title.'
+            exit 0
+          }
+
+          $dueDateUtc = [DateTime]::UtcNow.Date.AddDays(30).AddHours(12)
+          $dueDateTimestamp = [DateTimeOffset]::new($dueDateUtc).ToUnixTimeMilliseconds()
+
+          $customFields = @(
+            [ordered]@{
+              name = 'State'
+              '$type' = 'StateIssueCustomField'
+              value = [ordered]@{ name = 'Open' }
+            }
+            [ordered]@{
+              name = 'Type'
+              '$type' = 'SingleEnumIssueCustomField'
+              value = [ordered]@{ name = 'Task' }
+            }
+            [ordered]@{
+              name = 'Priority'
+              '$type' = 'SingleEnumIssueCustomField'
+              value = [ordered]@{ name = 'Normal' }
+            }
+            [ordered]@{
+              name = 'Edition'
+              '$type' = 'SingleOwnedIssueCustomField'
+              value = [ordered]@{ name = 'Studio' }
+            }
+            [ordered]@{
+              name = 'Go-Live'
+              '$type' = 'SingleOwnedIssueCustomField'
+              value = [ordered]@{ name = 'Nein' }
+            }
+            [ordered]@{
+              name = 'Due Date'
+              '$type' = 'DateIssueCustomField'
+              value = $dueDateTimestamp
+            }
+          )
+
+          if ($env:BASE_BRANCH -match '^\d+\.\d+\.\d+$') {
+            Write-Host "Sprint: $env:BASE_BRANCH"
+            $customFields += [ordered]@{
+              name = 'Sprints'
+              '$type' = 'MultiVersionIssueCustomField'
+              value = @([ordered]@{ name = $env:BASE_BRANCH })
+            }
+          }
+          else {
+            Write-Host "Base branch '$env:BASE_BRANCH' is not a stable version branch; no sprint is assigned."
+          }
+
+          $payload = [ordered]@{
+            project = [ordered]@{ id = '0-3' }
+            summary = "Dependency Update: $prTitle"
+            description = "Automatisch erstellt für [PR #$env:PR_NUMBER]($env:PR_URL)"
+            customFields = $customFields
+          } | ConvertTo-Json -Depth 10
+
+          $uri = "$($env:YT_BASE.TrimEnd('/'))/api/issues?fields=idReadable"
+          $headers = @{ Authorization = "Bearer $env:YT_TOKEN" }
+
+          try {
+            $response = Invoke-RestMethod `
+              -Method Post `
+              -Uri $uri `
+              -Headers $headers `
+              -ContentType 'application/json; charset=utf-8' `
+              -Body $payload
+          }
+          catch {
+            $details = if ($_.ErrorDetails.Message) { $_.ErrorDetails.Message } else { $_.Exception.Message }
+            throw "YouTrack ticket creation failed: $details"
+          }
+
+          $ticketId = [string]$response.idReadable
+          if ([string]::IsNullOrWhiteSpace($ticketId)) {
+            throw "YouTrack response did not contain an idReadable value: $($response | ConvertTo-Json -Depth 10 -Compress)"
+          }
+
+          Write-Host "Created YouTrack ticket $ticketId."
+          $editOutput = & gh pr edit $env:PR_NUMBER `
+            --repo $env:GITHUB_REPOSITORY `
+            --title "$ticketId $prTitle" 2>&1
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to update pull request title: $($editOutput | Out-String)"
+          }
+
+  validate-ticket:
+    name: Require RS ticket
+    needs:
+      - dependabot-ticket
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: renderkit
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: pwsh
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Require successful Dependabot ticket creation
+        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && needs.dependabot-ticket.result != 'success' }}
+        env:
+          DEPENDABOT_TICKET_RESULT: ${{ needs.dependabot-ticket.result }}
+        run: |
+          Write-Error "Dependabot YouTrack ticket job result: $env:DEPENDABOT_TICKET_RESULT"
+          exit 1
+
+      - name: Check out RenderKit Studio
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.23.0'
+          package-manager-cache: false
+
+      - name: Test ticket validation rules
+        run: node scripts/Test-ValidateChangeTicket.mjs
+
+      - name: Read current pull request title
+        id: current-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $titleOutput = & gh pr view $env:PR_NUMBER `
+            --repo $env:GITHUB_REPOSITORY `
+            --json title `
+            --jq '.title' 2>&1
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to read pull request title: $($titleOutput | Out-String)"
+          }
+
+          $title = ($titleOutput | Out-String).Trim()
+          "title=$title" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Validate pull request title
+        run: node scripts/Validate-ChangeTicket.mjs
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ steps.current-pr.outputs.title }}
+
+  update-changelog:
+    name: Update Unreleased changelog
+    if: ${{ github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip changelog]') }}
+    runs-on: renderkit
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: pwsh
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out current branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.23.0'
+          package-manager-cache: false
+
+      - name: Test changelog scope rules
+        run: node scripts/Test-ChangelogScope.mjs
+
+      - name: Check changelog scope
+        id: changelog-scope
+        run: node scripts/Check-ChangelogScope.mjs
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+
+      - name: Update changelog
+        if: ${{ steps.changelog-scope.outputs.required == 'true' }}
+        id: changelog
+        run: node scripts/Update-Changelog.mjs
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Commit changelog update
+        if: ${{ steps.changelog.outputs.changed == 'true' }}
+        env:
+          CHANGELOG_TICKETS: ${{ steps.changelog.outputs.tickets }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          git config user.name 'github-actions[bot]'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          git add -- CHANGELOG.md
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          git diff --cached --quiet
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host 'No changelog changes to commit.'
+            exit 0
+          }
+          if ($LASTEXITCODE -ne 1) { exit $LASTEXITCODE }
+
+          git commit -m "chore(changelog): $env:CHANGELOG_TICKETS update Unreleased [skip changelog]"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          git pull --rebase origin $env:GITHUB_REF_NAME
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          git push origin "HEAD:$env:GITHUB_REF_NAME"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -175,12 +175,12 @@ jobs:
           exit 1
 
       - name: Check out RenderKit
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '22.23.0'
           package-manager-cache: false
@@ -215,7 +215,7 @@ jobs:
 
   update-changelog:
     name: Update Unreleased changelog
-    if: ${{ github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip changelog]') }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -226,14 +226,14 @@ jobs:
 
     steps:
       - name: Check out current branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
           persist-credentials: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '22.23.0'
           package-manager-cache: false
@@ -248,12 +248,12 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
       - name: Update changelog
-        if: ${{ steps.changelog-scope.outputs.required == 'true' }}
         id: changelog
         run: node scripts/Update-Changelog.mjs
         env:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.event.after }}
+          PROCESS_ENTRIES: ${{ steps.changelog-scope.outputs.required }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Commit changelog update
@@ -279,7 +279,15 @@ jobs:
           }
           if ($LASTEXITCODE -ne 1) { exit $LASTEXITCODE }
 
-          git commit -m "chore(changelog): $env:CHANGELOG_TICKETS update Unreleased [skip changelog]"
+          $ticketText = ([string]$env:CHANGELOG_TICKETS).Trim()
+          $commitMessage = if ([string]::IsNullOrWhiteSpace($ticketText)) {
+            'chore(changelog): normalize structure [skip changelog]'
+          }
+          else {
+            "chore(changelog): $ticketText update Unreleased [skip changelog]"
+          }
+
+          git commit -m $commitMessage
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           git pull --rebase origin $env:GITHUB_REF_NAME

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
   dependabot-ticket:
     name: Dependabot YouTrack Ticket
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
       run:
@@ -48,11 +48,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
 
           if ([string]::IsNullOrWhiteSpace($env:YT_BASE)) {
-            throw 'YouTrack base URL is missing. Configure the repository variable YT_BASE_URL, for example https://example.youtrack.cloud.'
-          }
-
-          if ($env:YT_BASE -match 'deine-instanz') {
-            throw 'YouTrack base URL still contains the placeholder deine-instanz. Configure the repository variable YT_BASE_URL.'
+            throw 'YouTrack base URL is missing. Configure the repository variable YT_BASE_URL.'
           }
 
           if ([string]::IsNullOrWhiteSpace($env:YT_TOKEN)) {
@@ -95,11 +91,6 @@ jobs:
               value = [ordered]@{ name = 'Normal' }
             }
             [ordered]@{
-              name = 'Edition'
-              '$type' = 'SingleOwnedIssueCustomField'
-              value = [ordered]@{ name = 'Studio' }
-            }
-            [ordered]@{
               name = 'Go-Live'
               '$type' = 'SingleOwnedIssueCustomField'
               value = [ordered]@{ name = 'Nein' }
@@ -125,7 +116,7 @@ jobs:
 
           $payload = [ordered]@{
             project = [ordered]@{ id = '0-3' }
-            summary = "Dependency Update: $prTitle"
+            summary = "RenderKit Dependency Update: $prTitle"
             description = "Automatisch erstellt für [PR #$env:PR_NUMBER]($env:PR_URL)"
             customFields = $customFields
           } | ConvertTo-Json -Depth 10
@@ -165,7 +156,7 @@ jobs:
     needs:
       - dependabot-ticket
     if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: renderkit
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
       run:
@@ -183,7 +174,7 @@ jobs:
           Write-Error "Dependabot YouTrack ticket job result: $env:DEPENDABOT_TICKET_RESULT"
           exit 1
 
-      - name: Check out RenderKit Studio
+      - name: Check out RenderKit
         uses: actions/checkout@v7
         with:
           persist-credentials: false
@@ -225,7 +216,7 @@ jobs:
   update-changelog:
     name: Update Unreleased changelog
     if: ${{ github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip changelog]') }}
-    runs-on: renderkit
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,13 +36,13 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
         uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
         with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
+          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from Codacy
           # You can also omit the token and run the tools that support default configurations
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           verbose: true
@@ -51,11 +51,11 @@ jobs:
           # Adjust severity of non-security issues
           gh-code-scanning-compat: true
           # Force 0 exit code to allow SARIF file generation
-          # This will handover control about PR rejection to the GitHub side
+          # This hands PR rejection control to the GitHub side
           max-allowed-issues: 2147483647
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@main
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       - name: Install MKVToolNix on Ubuntu
         if: matrix.os == 'ubuntu-latest'
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Pester results
         if: always()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: pester-results-${{ matrix.os }}-${{ matrix.shell }}
           path: artifacts/test-results/*.xml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       - name: Run PSScriptAnalyzer
         shell: pwsh
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload SARIF results file
         if: ${{ always() && hashFiles('results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@main
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           sarif_file: results.sarif
 
@@ -108,10 +108,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@main
+        uses: actions/setup-dotnet@v6.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload build diagnostics
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: RenderKit-build-diagnostics
           path: |
@@ -133,7 +133,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload package
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: RenderKit-validation-package
           path: artifacts/packages/*.nupkg
@@ -146,10 +146,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       - name: Download package
-        uses: actions/download-artifact@main
+        uses: actions/download-artifact@v8.0.1
         with:
           name: RenderKit-validation-package
           path: artifacts/packages
@@ -176,10 +176,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       - name: Download package
-        uses: actions/download-artifact@main
+        uses: actions/download-artifact@v8.0.1
         with:
           name: RenderKit-validation-package
           path: artifacts/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@main
+        uses: actions/setup-dotnet@v6.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -46,58 +46,59 @@ jobs:
           "STAGE_PATH=$($result.StagePath)"                     >> $env:GITHUB_OUTPUT
 
       - name: Upload .nupkg artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: RenderKit-${{ steps.build.outputs.VERSION }}-nupkg
           path: ${{ steps.build.outputs.NUPKG_PATH }}
           if-no-files-found: error
 
       - name: Upload staged module artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: RenderKit-${{ steps.build.outputs.VERSION }}-stage
           path: ${{ steps.build.outputs.STAGE_PATH }}
-          if-no-files-found: error       
+          if-no-files-found: error
+
   package-compatibility:
-      name: Validate supported installers
-      needs: build
-      runs-on: windows-latest
+    name: Validate supported installers
+    needs: build
+    runs-on: windows-latest
 
-      steps:
-        - name: Checkout
-          uses: actions/checkout@main
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
 
-        - name: Download .nupkg artifact
-          uses: actions/download-artifact@main
-          with:
-            name: RenderKit-${{ needs.build.outputs.version }}-nupkg
-            path: ./artifacts
+      - name: Download .nupkg artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: RenderKit-${{ needs.build.outputs.version }}-nupkg
+          path: ./artifacts
 
-        - name: Validate PSResourceGet installation
-          shell: pwsh
-          run: |
-            $package = Get-Item ./artifacts/*.nupkg
-            ./build/Test-RenderKitLocalInstall.ps1 `
-              -PackagePath $package.FullName `
-              -Version '${{ needs.build.outputs.version }}' `
-              -PackageManager PSResourceGet
+      - name: Validate PSResourceGet installation
+        shell: pwsh
+        run: |
+          $package = Get-Item ./artifacts/*.nupkg
+          ./build/Test-RenderKitLocalInstall.ps1 `
+            -PackagePath $package.FullName `
+            -Version '${{ needs.build.outputs.version }}' `
+            -PackageManager PSResourceGet
 
-        - name: Install PowerShellGet 2.2.5
-          shell: powershell
-          run: |
-            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-            Install-Module -Name PowerShellGet -RequiredVersion 2.2.5 -Scope CurrentUser -Force -AllowClobber
+      - name: Install PowerShellGet 2.2.5
+        shell: powershell
+        run: |
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+          Install-Module -Name PowerShellGet -RequiredVersion 2.2.5 -Scope CurrentUser -Force -AllowClobber
 
-        - name: Validate PowerShellGet installation
-          shell: powershell
-          run: |
-            Import-Module PowerShellGet -RequiredVersion 2.2.5 -Force
-            $package = Get-Item ./artifacts/*.nupkg
-            ./build/Test-RenderKitLocalInstall.ps1 `
-              -PackagePath $package.FullName `
-              -Version '${{ needs.build.outputs.version }}' `
-              -PackageManager PowerShellGet
+      - name: Validate PowerShellGet installation
+        shell: powershell
+        run: |
+          Import-Module PowerShellGet -RequiredVersion 2.2.5 -Force
+          $package = Get-Item ./artifacts/*.nupkg
+          ./build/Test-RenderKitLocalInstall.ps1 `
+            -PackagePath $package.FullName `
+            -Version '${{ needs.build.outputs.version }}' `
+            -PackageManager PowerShellGet
 
   github-release:
     name: GitHub Release
@@ -110,12 +111,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Download .nupkg artifact
-        uses: actions/download-artifact@main
+        uses: actions/download-artifact@v8.0.1
         with:
           name: RenderKit-${{ needs.build.outputs.version }}-nupkg
           path: ./artifacts
@@ -159,7 +160,7 @@ jobs:
           No changelog entry found for version $version.
 
           Expected a heading such as:
-          ## $version - YYYY-MM-DD
+          ## [$version] - YYYY-MM-DD
           "@
           }
 
@@ -276,7 +277,7 @@ jobs:
 
     steps:
       - name: Download .nupkg artifact
-        uses: actions/download-artifact@main
+        uses: actions/download-artifact@v8.0.1
         with:
           name: RenderKit-${{ needs.build.outputs.version }}-nupkg
           path: ./artifacts
@@ -301,7 +302,7 @@ jobs:
 
     steps:
       - name: Download staged module
-        uses: actions/download-artifact@main
+        uses: actions/download-artifact@v8.0.1
         with:
           name: RenderKit-${{ needs.build.outputs.version }}-stage
           path: ./stage
@@ -348,7 +349,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7.0.1
 
       - name: Validate with PSResourceGet
         shell: pwsh

--- a/.github/workflows/sync-dependabot-target.yml
+++ b/.github/workflows/sync-dependabot-target.yml
@@ -1,0 +1,95 @@
+name: Sync Dependabot Target Branch
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync-target:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Detect highest semantic-version branch
+        id: detect
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $remoteHeads = & git ls-remote --heads origin 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to list remote branches: $($remoteHeads | Out-String)"
+          }
+
+          $versions = foreach ($line in $remoteHeads) {
+            if ($line -match 'refs/heads/(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
+              [pscustomobject]@{
+                Name = $Matches.version
+                Version = [version]$Matches.version
+              }
+            }
+          }
+
+          $highest = $versions |
+            Sort-Object -Property Version -Descending |
+            Select-Object -First 1
+
+          $target = if ($null -ne $highest) { $highest.Name } else { 'main' }
+          Write-Host "Dependabot target branch: $target"
+          "branch=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Update dependabot.yml target branch
+        env:
+          TARGET_BRANCH: ${{ steps.detect.outputs.branch }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $path = '.github/dependabot.yml'
+          $content = Get-Content -LiteralPath $path -Raw -Encoding utf8
+
+          if ($content -notmatch '(?m)^\s+target-branch:\s*\S+\s*$') {
+            throw 'dependabot.yml does not contain the expected target-branch field.'
+          }
+
+          $updated = [regex]::Replace(
+            $content,
+            '(?m)^(\s+)target-branch:\s*\S+\s*$',
+            "`$1target-branch: $env:TARGET_BRANCH"
+          )
+
+          if ($updated -ne $content) {
+            Set-Content -LiteralPath $path -Value $updated -Encoding utf8 -NoNewline
+          }
+
+      - name: Commit target update when required
+        env:
+          TARGET_BRANCH: ${{ steps.detect.outputs.branch }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          git diff --quiet -- .github/dependabot.yml
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host 'Dependabot target is already current.'
+            exit 0
+          }
+          if ($LASTEXITCODE -ne 1) { exit $LASTEXITCODE }
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -- .github/dependabot.yml
+          git commit -m "ci: sync dependabot target to $env:TARGET_BRANCH [skip changelog]"
+          git pull --rebase origin $env:GITHUB_REF_NAME
+          git push origin "HEAD:$env:GITHUB_REF_NAME"

--- a/.github/workflows/sync-dependabot-target.yml
+++ b/.github/workflows/sync-dependabot-target.yml
@@ -35,6 +35,24 @@ jobs:
             throw 'Unable to fetch remote branches.'
           }
 
+          $mainManifest = & git show 'origin/main:RenderKit.psd1' 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to read RenderKit.psd1 from main: $($mainManifest | Out-String)"
+          }
+
+          $mainManifestText = $mainManifest | Out-String
+          $mainVersionMatch = [regex]::Match(
+            $mainManifestText,
+            "(?m)^\s*ModuleVersion\s*=\s*'(?<version>[0-9]+\.[0-9]+\.[0-9]+)'"
+          )
+          if (-not $mainVersionMatch.Success) {
+            throw 'Unable to resolve ModuleVersion from origin/main:RenderKit.psd1.'
+          }
+
+          $mainVersionText = $mainVersionMatch.Groups['version'].Value
+          $mainVersion = [version]$mainVersionText
+          Write-Host "Current main version: $mainVersionText"
+
           $remoteRefs = & git for-each-ref --format='%(refname:short)' refs/remotes/origin
           if ($LASTEXITCODE -ne 0) {
             throw 'Unable to enumerate remote branches.'
@@ -42,28 +60,24 @@ jobs:
 
           $versions = foreach ($ref in $remoteRefs) {
             if ($ref -match '^origin/(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
-              [pscustomobject]@{
-                Name = $Matches.version
-                Version = [version]$Matches.version
+              $candidateVersion = [version]$Matches.version
+              if ($candidateVersion -gt $mainVersion) {
+                [pscustomobject]@{
+                  Name = $Matches.version
+                  Version = $candidateVersion
+                }
+              }
+              else {
+                Write-Host "Skipping released/stale branch $($Matches.version) because main is $mainVersionText."
               }
             }
           }
 
-          $target = 'main'
-          foreach ($candidate in ($versions | Sort-Object -Property Version -Descending)) {
-            & git merge-base --is-ancestor "origin/$($candidate.Name)" 'origin/main'
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "Skipping merged release branch $($candidate.Name)."
-              continue
-            }
-            if ($LASTEXITCODE -ne 1) {
-              throw "Unable to compare release branch $($candidate.Name) with main."
-            }
+          $highest = $versions |
+            Sort-Object -Property Version -Descending |
+            Select-Object -First 1
 
-            $target = $candidate.Name
-            break
-          }
-
+          $target = if ($null -ne $highest) { $highest.Name } else { 'main' }
           Write-Host "Dependabot target branch: $target"
           "branch=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -74,15 +88,16 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $path = '.github/dependabot.yml'
           $content = Get-Content -LiteralPath $path -Raw -Encoding utf8
+          $targetPattern = '(?m)^(?<indent>[ \t]+)target-branch:[ \t]*\S+[ \t]*$'
 
-          if ($content -notmatch '(?m)^\s+target-branch:\s*\S+\s*$') {
+          if ($content -notmatch $targetPattern) {
             throw 'dependabot.yml does not contain the expected target-branch field.'
           }
 
           $updated = [regex]::Replace(
             $content,
-            '(?m)^(\s+)target-branch:\s*\S+\s*$',
-            "`$1target-branch: $env:TARGET_BRANCH"
+            $targetPattern,
+            "`${indent}target-branch: $env:TARGET_BRANCH"
           )
 
           if ($updated -ne $content) {

--- a/.github/workflows/sync-dependabot-target.yml
+++ b/.github/workflows/sync-dependabot-target.yml
@@ -25,18 +25,23 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Detect highest semantic-version branch
+      - name: Detect highest active semantic-version branch
         id: detect
         run: |
           $ErrorActionPreference = 'Stop'
 
-          $remoteHeads = & git ls-remote --heads origin 2>&1
+          & git fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
           if ($LASTEXITCODE -ne 0) {
-            throw "Unable to list remote branches: $($remoteHeads | Out-String)"
+            throw 'Unable to fetch remote branches.'
           }
 
-          $versions = foreach ($line in $remoteHeads) {
-            if ($line -match 'refs/heads/(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
+          $remoteRefs = & git for-each-ref --format='%(refname:short)' refs/remotes/origin
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to enumerate remote branches.'
+          }
+
+          $versions = foreach ($ref in $remoteRefs) {
+            if ($ref -match '^origin/(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
               [pscustomobject]@{
                 Name = $Matches.version
                 Version = [version]$Matches.version
@@ -44,11 +49,21 @@ jobs:
             }
           }
 
-          $highest = $versions |
-            Sort-Object -Property Version -Descending |
-            Select-Object -First 1
+          $target = 'main'
+          foreach ($candidate in ($versions | Sort-Object -Property Version -Descending)) {
+            & git merge-base --is-ancestor "origin/$($candidate.Name)" 'origin/main'
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Skipping merged release branch $($candidate.Name)."
+              continue
+            }
+            if ($LASTEXITCODE -ne 1) {
+              throw "Unable to compare release branch $($candidate.Name) with main."
+            }
 
-          $target = if ($null -ne $highest) { $highest.Name } else { 'main' }
+            $target = $candidate.Name
+            break
+          }
+
           Write-Host "Dependabot target branch: $target"
           "branch=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 

--- a/.github/workflows/sync-dependabot-target.yml
+++ b/.github/workflows/sync-dependabot-target.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out default branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/youtrack-pr-close.yml
+++ b/.github/workflows/youtrack-pr-close.yml
@@ -1,0 +1,102 @@
+name: Update YouTrack on PR close
+
+on:
+  pull_request:
+    branches:
+      - main
+      - '*.*.*'
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: youtrack-pr-close-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  update-youtrack-state:
+    name: Update linked YouTrack ticket
+    if: ${{ contains(github.event.pull_request.title, 'RS-') }}
+    runs-on: windows-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Set YouTrack ticket state
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          YT_BASE: ${{ vars.YT_BASE_URL }}
+          YT_TOKEN: ${{ secrets.YT_API_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ([string]::IsNullOrWhiteSpace($env:YT_BASE)) {
+            throw 'YouTrack base URL is missing. Configure the repository variable YT_BASE_URL.'
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:YT_TOKEN)) {
+            throw 'YouTrack token is missing. Configure YT_API_TOKEN as both an Actions secret and a Dependabot secret.'
+          }
+
+          $ticketIds = [regex]::Matches(
+            $env:PR_TITLE,
+            '(?<![A-Za-z0-9])RS-[0-9]+(?![A-Za-z0-9])'
+          ) |
+            ForEach-Object { $_.Value.ToUpperInvariant() } |
+            Select-Object -Unique
+
+          if (-not $ticketIds) {
+            Write-Host "No RS ticket ID found in closed PR #$env:PR_NUMBER; nothing to update."
+            exit 0
+          }
+
+          $targetState = if ($env:PR_AUTHOR -eq 'dependabot[bot]') {
+            'Done'
+          }
+          else {
+            'Functional Review'
+          }
+
+          $headers = @{
+            Authorization = "Bearer $($env:YT_TOKEN.Trim())"
+            Accept = 'application/json'
+          }
+
+          foreach ($ticketId in $ticketIds) {
+            $payload = [ordered]@{
+              customFields = @(
+                [ordered]@{
+                  name = 'State'
+                  '$type' = 'StateIssueCustomField'
+                  value = [ordered]@{ name = $targetState }
+                }
+              )
+            } | ConvertTo-Json -Depth 6
+
+            $encodedTicketId = [Uri]::EscapeDataString($ticketId)
+            $uri = "$($env:YT_BASE.TrimEnd('/'))/api/issues/${encodedTicketId}?fields=idReadable,customFields(name,value(name))"
+
+            try {
+              Invoke-RestMethod `
+                -Method Post `
+                -Uri $uri `
+                -Headers $headers `
+                -ContentType 'application/json; charset=utf-8' `
+                -Body $payload | Out-Null
+            }
+            catch {
+              $details = if ($_.ErrorDetails.Message) { $_.ErrorDetails.Message } else { $_.Exception.Message }
+              throw "Unable to set YouTrack ticket $ticketId to '$targetState': $details"
+            }
+
+            Write-Host "Set YouTrack ticket $ticketId to '$targetState' after PR #$env:PR_NUMBER was closed (merged: $env:PR_MERGED)."
+            Write-Host "PR: $env:PR_URL"
+          }

--- a/.github/workflows/youtrack-pr-close.yml
+++ b/.github/workflows/youtrack-pr-close.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   update-youtrack-state:
     name: Update linked YouTrack ticket
-    if: ${{ contains(github.event.pull_request.title, 'RS-') }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.title, 'RS-') }}
     runs-on: windows-latest
     timeout-minutes: 5
     defaults:
@@ -43,7 +43,7 @@ jobs:
           }
 
           if ([string]::IsNullOrWhiteSpace($env:YT_TOKEN)) {
-            throw 'YouTrack token is missing. Configure YT_API_TOKEN as both an Actions secret and a Dependabot secret.'
+            throw 'YouTrack token is missing. Configure YT_API_TOKEN as an Actions secret.'
           }
 
           $ticketIds = [regex]::Matches(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,34 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
+## 1.1.3 - 2026-07-31
 
 ### Added
 
+- Added RS-798/RS-799 worker capability discovery for local and registered
+  backup workers, including per-worker CPU, GPU, FFmpeg, and encoder support.
+- Added per-worker backup-profile execution results with eligible worker IDs,
+  compatibility states, and CPU-fallback reporting without preventing users
+  from storing structurally valid custom profiles.
+- Added RS-1204 machine-readable and documented RenderKit file-format
+  definitions for the ZIP-based `.rkit` and `.rkitpkg` project archives.
+
 ### Changed
 
-### Deprecated
-
-### Removed
+- RS-1204 project exports now always append the canonical `.rkit` or
+  `.rkitpkg` extension when another extension is requested, normalize canonical
+  extension casing, and continue returning the effective output path.
+- RS-798/RS-799 hardware validation now evaluates every available worker
+  independently and preserves offline worker registrations for heterogeneous
+  future worker pools.
 
 ### Fixed
 
-### Security
+- Fixed RS-1129 automatic encoder selection treating an FFmpeg encoder as
+  usable when the installed GPU cannot execute it. Hardware encoders are now
+  probed with a real one-frame encode at supported dimensions and safely fall
+  back to a compatible CPU encoder.
 
-## [1.1.2] - 2026-07-23
+## 1.1.2 - 2026-07-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## 1.1.3 - 2026-07-31
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.1.3] - 2026-07-31
 
 ### Added
 
@@ -28,7 +47,7 @@
   probed with a real one-frame encode at supported dimensions and safely fall
   back to a compatible CPU encoder.
 
-## 1.1.2 - 2026-07-23
+## [1.1.2] - 2026-07-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
-## 1.1.2 - 2026-07-23
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.1.2] - 2026-07-23
 
 ### Added
 
@@ -24,7 +44,7 @@
   terminal `Archived` lifecycle status; legacy backup-generated archive
   transitions are now interpreted as their preceding status.
 
-## 1.1.1 - 2026-07-23
+## [1.1.1] - 2026-07-23
 
 ### Fixed
 
@@ -36,7 +56,7 @@
 - Fixed mapping template resolution so mapping identifiers are consistently
   normalized to their corresponding `.json` files before loading.
 
-## 1.1.0 - 2026-07-11
+## [1.1.0] - 2026-07-11
 
 ### Added
 
@@ -159,7 +179,7 @@
 - Fixed successful structured ExifTool imports being reported as failures by
   Windows PowerShell 5.1 when ExifTool writes its status line to stderr.
   
-## 1.0.1 - 2026-07-01
+## [1.0.1] - 2026-07-01
 
 ### Patch
 
@@ -174,7 +194,7 @@
 - Fixed large files monopolizing the complete in-flight budget until read-back verification completed. Pipeline admission now accounts for estimated resident buffers rather than logical file size.
 - Added `-TransferVerificationMode Fast|Full`. The default `Fast` mode uses the native file-copy path with staging-length validation and atomic commit, while `Full` retains independent SHA read-back verification.
 
-## 1.0.0 - 2026-06-19
+## [1.0.0] - 2026-06-19
 
 ### Major
 
@@ -228,7 +248,7 @@
 - Fixed project logging so `Write-RenderKitLog` no longer calls `Add-Content` directly against a potentially deleted `renderkit.log`; it now routes file writes through `Write-RenderKitLogFileEntry`.
 - Fixed the debug-level comparison typo so debug entries are written when `-Level Debug` is used.
 
-## 0.3.9 - 2026-06-18
+## [0.3.9] - 2026-06-18
 
 ### Patch
 
@@ -246,7 +266,7 @@
 - Fixed release builds after removal of the optional RenderKit logo asset by omitting icon metadata and package files when the image is not present.
 - Improved `dotnet pack` failure reporting by preserving the native exit code, printing normal-verbosity output, including the generated nuspec in the exception, and uploading staging diagnostics from CI.
 
-## 0.3.8 - 2026-06-16
+## [0.3.8] - 2026-06-16
 
 ### Patch
 
@@ -284,7 +304,7 @@
 - Fixed exported documentation coverage by listing the newly merged project lifecycle and delivery commands.
 - Fixed release publishing robustness by registering PSGallery idempotently before `Publish-PSResource` runs.
 
-## 0.3.7 - 2026-04-21
+## [0.3.7] - 2026-04-21
 
 ### Patch
 
@@ -304,7 +324,7 @@
 - Fixed wizard configuration binding so classification now reads `wizardConfig.Classify` correctly
 - Fixed wizard transfer prompting so the transfer mode menu only appears when transfer was enabled during setup
 
-## 0.3.6 - 2026-04-xx
+## [0.3.6] - 2026-04-xx
 
 ### Patch
 
@@ -342,7 +362,7 @@
 - Fixes #124 - PSScriptAnalyzer Warning
 - Fixes #112 - PSScriptAnalyzer Warning
 
-## 0.3.5 - 2026-04-11
+## [0.3.5] - 2026-04-11
 
 ### Patch
 
@@ -367,7 +387,7 @@
  Replaced `Copy-Item` with stream-based copying and continous progress updates (copy, source hash, staging hash), improving responsiveness and visibility during long operations.
  Relevant file: `RenderKit.ImportService.ps1`
 
-## 0.3.4 - 2026-04-10
+## [0.3.4] - 2026-04-10
 
 ### Patch
 
@@ -375,7 +395,7 @@
 
 - Refactored the .psm1 file for robust dot sourcing
 
-## 0.3.3 - 2026-04-04
+## [0.3.3] - 2026-04-04
 
 ### Patch
 
@@ -394,7 +414,7 @@
 
 - Removed some PluralNouns that make sense. Suppressed some others.
 
-## 0.3.2 - 2026.04.02
+## [0.3.2] - 2026.04.02
 
 ### Patch
 
@@ -404,7 +424,7 @@
 
 - Fixed a minor error in  "FunctionsToExport" segment in the Manifest file.
 
-## 0.3.1 - 2026-04-02
+## [0.3.1] - 2026-04-02
 
 ### Patch
 
@@ -414,7 +434,7 @@
 
 - Removed trailing white spaces in the code
 
-## 0.3.0 – 2026-03-31
+## [0.3.0] - 2026-03-31
 
 ### Minor Release
 
@@ -469,7 +489,7 @@
 
 - No changes
 
-## 0.2.0 – 2026-02-11
+## [0.2.0] - 2026-02-11
 
 ### Minor Release
 
@@ -543,7 +563,7 @@
 
 - No changes
 
-## 0.1.0 2026.01.29
+## [0.1.0] - 2026.01.29
 
 ### Added
 

--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'RenderKit.psm1'
-    ModuleVersion = '1.1.2' # Major.Minor.Patch
+    ModuleVersion = '1.1.3' # Major.Minor.Patch
     Author = 'Norbert Marton'
     Description = 'PowerShell tools for structured video editing project workflows.'
     GUID = '32e3f476-8e44-4511-82c7-952748e6463b'
@@ -101,13 +101,11 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-Version 1.1.2 improves RenderKit Studio media-import integration and resource portability:
-- Imports complete template and mapping documents with explicit conflict handling.
-- Exports system or user resources for automation and interchange.
-- Validates stored resources through stable public commands and structured results.
-- Streams measured import phase and transfer progress through PowerShell hosts.
-- Rejects transfers into terminal projects and preserves lifecycle state during normal backups.
-- Preserves atomic persistence and Windows PowerShell 5.1 compatibility.
+Version 1.1.3 improves backup worker compatibility and project archive portability:
+- Adds worker capability discovery and per-worker backup profile compatibility reporting.
+- Probes advertised hardware encoders with a real one-frame encode before automatic selection and safely falls back to CPU encoding.
+- Preserves offline worker registrations while reporting compatible workers for heterogeneous worker pools.
+- Defines the canonical RenderKit project archive formats and enforces `.rkit` and `.rkitpkg` export extensions.
 '@
         } # End of PSData hashtable
 

--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -21,6 +21,7 @@
         'Backup-Project'
         'Get-BackupAdapter'
         'Get-BackupConfigProfile'
+        'Get-BackupWorkerCapability'
         'Get-BackupJob'
         'Get-Metadata'
         'Get-MetadataTemplate'

--- a/RenderKit.psm1
+++ b/RenderKit.psm1
@@ -12,6 +12,7 @@ $script:RenderKitPublicFunctions = @(
     'Backup-Project'
     'Get-BackupAdapter'
     'Get-BackupConfigProfile'
+    'Get-BackupWorkerCapability'
     'Get-BackupJob'
     'Get-Metadata'
     'Get-MetadataTemplate'

--- a/Tests/Backup/RenderKit.BackupCommandContract.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupCommandContract.Tests.ps1
@@ -97,6 +97,7 @@ Describe 'RenderKit backup command contracts' {
     It 'exposes the backup config profile creator lifecycle' {
         foreach ($commandName in @(
                 'New-BackupConfigProfile',
+                'Get-BackupWorkerCapability',
                 'Set-BackupConfigProfile',
                 'Test-BackupConfigProfile',
                 'Export-BackupConfigProfile',

--- a/Tests/Backup/RenderKit.BackupConfigProfile.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupConfigProfile.Tests.ps1
@@ -259,6 +259,105 @@ Describe 'RenderKit backup config profile creator' {
         @(Get-BackupConfigProfile -Source User).Count | Should -Be 0
     }
 
+    It 'keeps structurally valid profiles while reporting worker incompatibility' {
+        $workers = @(
+            [PSCustomObject]@{
+                workerId = 'worker-h264'
+                machine = 'encode-01'
+                online = $true
+                devices = @(
+                    [PSCustomObject]@{
+                        id = 'CPU'
+                        codecs = @('H264', 'H265')
+                    }
+                    [PSCustomObject]@{
+                        id = 'Nvidia'
+                        codecs = @('H264')
+                    }
+                )
+            }
+        )
+
+        $result = Test-BackupConfigProfile `
+            -Name smallest `
+            -CheckHardware `
+            -WorkerCapability $workers
+
+        $result.IsValid | Should -BeTrue
+        $result.ExecutionCompatibility.Status | Should -Be 'Unavailable'
+        $result.ExecutionCompatibility.IsExecutable | Should -BeFalse
+        $result.ExecutionCompatibility.ResolvedCodec | Should -Be 'AV1'
+        $result.ExecutionCompatibility.Workers[0].Reason |
+            Should -Be 'NoCompatibleEncoder'
+    }
+
+    It 'evaluates heterogeneous workers independently' {
+        $workers = @(
+            [PSCustomObject]@{
+                workerId = 'worker-h264'
+                machine = 'encode-01'
+                online = $true
+                devices = @(
+                    [PSCustomObject]@{
+                        id = 'CPU'
+                        codecs = @('H264')
+                    }
+                    [PSCustomObject]@{
+                        id = 'Nvidia'
+                        codecs = @('H264')
+                    }
+                )
+            }
+            [PSCustomObject]@{
+                workerId = 'worker-av1'
+                machine = 'encode-02'
+                online = $true
+                devices = @(
+                    [PSCustomObject]@{
+                        id = 'CPU'
+                        codecs = @('H264', 'H265', 'AV1')
+                    }
+                    [PSCustomObject]@{
+                        id = 'IntelQuickSync'
+                        codecs = @('H264', 'H265', 'AV1')
+                    }
+                )
+            }
+        )
+
+        $result = Test-BackupConfigProfile `
+            -Name smallest `
+            -CheckHardware `
+            -WorkerCapability $workers
+
+        $result.ExecutionCompatibility.Status | Should -Be 'Degraded'
+        $result.ExecutionCompatibility.IsExecutable | Should -BeTrue
+        $result.ExecutionCompatibility.CompatibleWorkerIds |
+            Should -Contain 'worker-av1'
+        $result.ExecutionCompatibility.CompatibleWorkerIds |
+            Should -Not -Contain 'worker-h264'
+        $result.ExecutionCompatibility.Workers.Count | Should -Be 2
+    }
+
+    It 'does not require an encoder for archive-only profiles' {
+        $worker = [PSCustomObject]@{
+            workerId = 'archive-worker'
+            machine = 'archive-01'
+            online = $true
+            devices = @()
+        }
+
+        $result = Test-BackupConfigProfile `
+            -Name no-transcode `
+            -CheckHardware `
+            -WorkerCapability @($worker)
+
+        $result.ExecutionCompatibility.Status | Should -Be 'Available'
+        $result.ExecutionCompatibility.IsExecutable | Should -BeTrue
+        $result.ExecutionCompatibility.Workers[0].Reason |
+            Should -Be 'NoEncodingRequired'
+    }
+
     It 'rebases an existing user profile while applying explicit settings' {
         New-BackupConfigProfile `
             -Name rebase-me `

--- a/Tests/Backup/RenderKit.BackupProjectJob.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupProjectJob.Tests.ps1
@@ -1826,6 +1826,44 @@ Describe 'RenderKit BackupProject job planning' {
         $profile.encoderSelection.reason | Should -Be 'NoUsableHardwareEncoderDetected'
     }
 
+    It 'falls back to CPU when RS-1129 hardware probing rejects an advertised encoder' {
+        $profile = InModuleScope RenderKit {
+            $capabilities = New-BackupGpuCapabilityReport `
+                -EncoderNames @('h264_nvenc', 'hevc_nvenc', 'av1_nvenc') `
+                -VideoControllerNames @('NVIDIA GeForce GTX 1080 Ti') `
+                -DetectedCommands @('nvidia-smi') `
+                -FfmpegPath 'ffmpeg' `
+                -Source 'Test' `
+                -EncoderProbeResults @{
+                    h264_nvenc = [PSCustomObject]@{
+                        usable = $true
+                        reason = 'ProbeSucceeded'
+                    }
+                    hevc_nvenc = [PSCustomObject]@{
+                        usable = $true
+                        reason = 'ProbeSucceeded'
+                    }
+                    av1_nvenc = [PSCustomObject]@{
+                        usable = $false
+                        reason = 'ProbeFailed'
+                    }
+                } `
+                -RunBenchmark
+            Get-BackupEncodingProfile `
+                -CompressionPreset Smallest `
+                -VideoCodec AV1 `
+                -EncoderDevice Auto `
+                -QualityPreset Smallest `
+                -AudioProfile Auto `
+                -GpuCapabilities $capabilities
+        }
+
+        $profile.videoCodec | Should -Be 'AV1'
+        $profile.encoderDevice | Should -Be 'CPU'
+        $profile.encoderName | Should -Be 'libsvtav1'
+        $profile.encoderSelection.source | Should -Be 'CpuFallback'
+    }
+
     It 'persists and reads the GPU capability cache' {
         $cached = InModuleScope RenderKit -Parameters @{
             CachePath = (Join-Path $TestDrive 'gpu-cache\gpu-capabilities.json')

--- a/Tests/Public/Export-Project.Tests.ps1
+++ b/Tests/Public/Export-Project.Tests.ps1
@@ -20,6 +20,7 @@ BeforeAll {
 
 Describe 'Export-Project' {
     BeforeEach {
+        $script:RenderKitFileFormatCatalog = $null
         $script:RenderKitArtifactVersionCatalog = $null
         $script:RenderKitArtifactMigrations = @{}
         $script:RenderKitModuleVersion = '0.0.0'
@@ -47,5 +48,84 @@ Describe 'Export-Project' {
         $expectedPath = Join-Path $destinationRoot 'ProjectA.rkit'
         $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
         Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'appends the canonical manifest extension to an arbitrary file extension' {
+        $projectRoot = Join-Path $TestDrive 'ProjectB'
+        $requestedPath = Join-Path $TestDrive 'exporttest.txt'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode ManifestOnly
+
+        $expectedPath = "$requestedPath.rkit"
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $requestedPath -PathType Leaf |
+            Should -BeFalse
+    }
+
+    It 'appends the canonical package extension for self-contained exports' {
+        $projectRoot = Join-Path $TestDrive 'ProjectC'
+        $requestedPath = Join-Path $TestDrive 'portable.zip'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode SelfContained
+
+        $expectedPath = "$requestedPath.rkitpkg"
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'normalizes the casing of an otherwise canonical extension' {
+        $projectRoot = Join-Path $TestDrive 'ProjectD'
+        $requestedPath = Join-Path $TestDrive 'manifest.RKIT'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        $result = Export-Project `
+            -ProjectRoot $projectRoot `
+            -DestinationPath $requestedPath `
+            -Mode ManifestOnly
+
+        $expectedPath = Join-Path $TestDrive 'manifest.rkit'
+        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($expectedPath))
+        Test-Path -LiteralPath $expectedPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'writes both RenderKit project formats as readable zip archives' {
+        $projectRoot = Join-Path $TestDrive 'ProjectE'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        Set-Content `
+            -LiteralPath (Join-Path $projectRoot 'asset.txt') `
+            -Value 'test asset'
+
+        foreach ($mode in @('ManifestOnly', 'SelfContained')) {
+            $requestedPath = Join-Path $TestDrive $mode
+            $result = Export-Project `
+                -ProjectRoot $projectRoot `
+                -DestinationPath $requestedPath `
+                -Mode $mode
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($result.Path)
+            try {
+                $archive.GetEntry('project.xml') | Should -Not -BeNullOrEmpty
+            }
+            finally {
+                $archive.Dispose()
+            }
+        }
     }
 }

--- a/build/Test-RenderKitPackage.ps1
+++ b/build/Test-RenderKitPackage.ps1
@@ -34,6 +34,7 @@ try {
         'src/Resources/Metadata/ixml-field-map.json',
         'src/Resources/Metadata/iptc-field-map.json',
         'src/Resources/Metadata/matroska-field-map.json',
+        'src/Resources/FileFormats/RenderKit.FileFormats.json',
         'src/Resources/ThirdParty/MediaInfo/manifest.json',
         'src/Resources/ThirdParty/ExifTool/manifest.json',
         'src/Resources/ThirdParty/ExifTool/files.sha256',

--- a/docs/Export-Project.md
+++ b/docs/Export-Project.md
@@ -21,7 +21,7 @@ Export-Project -ProjectRoot <string> -DestinationPath <string> [-Mode <string>] 
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `-ProjectRoot` | `string` | Yes | – | Full path to the project directory. |
-| `-DestinationPath` | `string` | Yes | – | Destination file path for the manifest/package, or an existing destination directory. Directory destinations create `<ProjectRootName>.rkit` for `ManifestOnly` exports and `<ProjectRootName>.rkitpkg` for `SelfContained` exports. |
+| `-DestinationPath` | `string` | Yes | – | Destination file path for the manifest/package, or an existing destination directory. RenderKit always appends the canonical `.rkit` or `.rkitpkg` extension when it is missing or another extension was supplied. Directory destinations create `<ProjectRootName>.rkit` for `ManifestOnly` exports and `<ProjectRootName>.rkitpkg` for `SelfContained` exports. |
 | `-Mode` | `string` | No | `'ManifestOnly'` | Export mode. |
 | `-CompressionMethod` | `string` | No | `'Zip'` | Compression method. |
 | `-CompressionLevel` | `string` | No | `'Optimal'` | Compression level. |
@@ -36,6 +36,19 @@ Export-Project -ProjectRoot "D:\Projects\ClientA" -DestinationPath "E:\Transfer"
 ```
 
 Exports `D:\Projects\ClientA` to `E:\Transfer\ClientA.rkit`.
+
+If a non-RenderKit extension is supplied, it remains part of the base file
+name and the canonical extension is appended:
+
+```powershell
+Export-Project `
+  -ProjectRoot "D:\Projects\ClientA" `
+  -DestinationPath "E:\Transfer\ClientA.zip" `
+  -Mode SelfContained
+```
+
+This writes `E:\Transfer\ClientA.zip.rkitpkg`. Existing files at the originally
+requested non-RenderKit path are not overwritten.
 
 
 Before running the command, inspect its full help with `Get-Help Export-Project -Full`. For commands that support `ShouldProcess`, use `-WhatIf` before making production changes.

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1,0 +1,36 @@
+# RenderKit file formats
+
+RenderKit-owned portable artifacts use a RenderKit-specific extension. The
+extension identifies the domain artifact; its underlying serialization remains
+available to standard tooling.
+
+## Active project formats
+
+| Extension | Artifact | Container | Media type |
+| --- | --- | --- | --- |
+| `.rkit` | Project manifest and portable resources | ZIP | `application/vnd.renderkit.project+zip` |
+| `.rkitpkg` | Self-contained project package including project files | ZIP | `application/vnd.renderkit.project-package+zip` |
+
+Both formats are valid ZIP archives and contain `project.xml` at the archive
+root. Operating-system integration may therefore classify them as ZIP-based
+archives without changing their RenderKit-specific extension.
+
+The machine-readable format identifiers used by Core and packaging integrations
+are stored in `src/Resources/FileFormats/RenderKit.FileFormats.json`.
+
+## Reserved portable artifact extensions
+
+The following extensions are reserved for future or migrated portability
+commands. Reserving them does not change the internal JSON files used by the
+RenderKit runtime.
+
+| Extension | Intended artifact |
+| --- | --- |
+| `.rkittemplate` | Portable project or metadata template |
+| `.rkitmapping` | Portable media mapping |
+| `.rkitprofile` | Portable backup or workflow profile |
+| `.rkitmetadata` | Portable metadata export |
+| `.rkitjobs` | Portable job-history collection |
+
+RenderKit types remain part of a mapping. A separate type extension should only
+be introduced if types become independently versioned and portable artifacts.

--- a/docs/development/changelog-automation.md
+++ b/docs/development/changelog-automation.md
@@ -1,0 +1,134 @@
+# Changelog automation
+
+RenderKit maintains `CHANGELOG.md` independently from the existing package and release workflows. The automation runs after pushes to `main` and semantic-version branches such as `1.1.3` or `1.2.0`.
+
+## Required RS ticket
+
+Pull requests targeting `main` or a semantic-version branch must normally include an RS ticket in their title:
+
+```text
+fix(backup): RS-1129 probe hardware encoders before backup
+```
+
+A pull request is exempt when its source branch consists only of one supported version:
+
+```text
+1.1.3
+1.1.3-rc1
+1.1.3-rc12
+```
+
+The exception is intentionally strict. Prefixes, paths, missing release-candidate numbers, and other suffixes remain ticket-required. These examples are not exempt:
+
+```text
+v1.1.3
+release/1.1.3
+1.1.3-rc
+1.1.3-beta1
+```
+
+RenderKit uses squash merges for normal release-branch work. A normal change therefore retains its ticket in the resulting squash commit and becomes the single change represented in the changelog. A version-only squash commit such as `1.1.3 (#81)` is treated as release orchestration and is skipped by changelog processing.
+
+Except for this version-only case, a pushed commit without an `RS-<number>` reference fails the changelog workflow and does not generate an entry.
+
+## Dependabot and YouTrack
+
+Dependabot is enabled only for the `github-actions` ecosystem. RenderKit's bundled native third-party tools are not managed by Dependabot because they are synchronized and verified through repository-specific asset logic rather than a supported package-manager manifest.
+
+Dependabot pull requests receive their YouTrack ticket inside the `Maintain changelog` workflow:
+
+```text
+Dependabot YouTrack Ticket
+  -> Require RS ticket
+```
+
+The prerequisite reads the current PR title, creates the YouTrack issue when no `RS-<number>` is present, and updates the title. `Require RS ticket` then reads the title again before validating it.
+
+The Dependabot target branch is synchronized weekly. The highest stable semantic-version branch is selected when one exists; otherwise the configuration falls back to `main`.
+
+Required repository configuration:
+
+```text
+Repository variable: YT_BASE_URL
+Actions secret:       YT_API_TOKEN
+Dependabot secret:    YT_API_TOKEN
+```
+
+The Dependabot secret is only required when Dependabot is enabled and must contain the same YouTrack token as the Actions secret.
+
+Core does not set a Studio-specific `Edition` custom field when creating dependency tickets.
+
+## Public repository runner boundary
+
+RenderKit is public. Pull-request changelog and ticket validation therefore runs on GitHub-hosted runners rather than persistent self-hosted RenderKit runners.
+
+This prevents untrusted fork pull requests from executing their checked-out code on privately managed runner hosts. The YouTrack close workflow additionally ignores PRs whose head repository is not the RenderKit repository.
+
+## Changelog format
+
+The updater follows Keep a Changelog semantics and maintains an `Unreleased` section with these categories:
+
+- `Added`
+- `Changed`
+- `Deprecated`
+- `Removed`
+- `Fixed`
+- `Security`
+
+Conventional Commit prefixes determine the generated category:
+
+| Prefix | Category |
+| --- | --- |
+| `feat:` | `Added` |
+| `fix:` | `Fixed` |
+| `security:` | `Security` |
+| `remove:` | `Removed` |
+| `deprecate:` | `Deprecated` |
+| all other prefixes | `Changed` |
+
+Each generated entry includes the ticket and the seven-character SHA of the squash commit:
+
+```markdown
+- **RS-1129:** Probed hardware encoders before automatic backup selection. (`a1b2c3d`)
+```
+
+The SHA is also used to prevent duplicate entries.
+
+## OpenAI fallback
+
+Commit subjects are used deterministically whenever they contain a useful description. OpenAI is called only when the remaining description is too short or generic.
+
+The optional repository secret is:
+
+```text
+OPENAI_API_KEY
+```
+
+If the secret is missing, the API is unavailable, or the request fails, the updater uses the cleaned commit subject. Changelog maintenance therefore does not depend on OpenAI availability.
+
+## Automated changelog commit
+
+When `CHANGELOG.md` changes, GitHub Actions creates a commit similar to:
+
+```text
+chore(changelog): RS-1129 update Unreleased [skip changelog]
+```
+
+The `[skip changelog]` marker prevents an automation loop.
+
+## Cutting a release
+
+Development changes accumulate under `## [Unreleased]`. Before a semantic-version branch is merged into `main`, finalize the release in the version branch:
+
+1. Set `RenderKit.psd1` `ModuleVersion` to the release version.
+2. Move the accumulated Unreleased release notes under a dated heading, for example:
+
+```markdown
+## [1.1.3] - 2026-08-07
+```
+
+3. Leave a fresh empty `## [Unreleased]` block above the released version.
+4. Ensure the release notes in `RenderKit.psd1` match the intended package release.
+5. Merge the version branch into `main` only after the release PR checks pass.
+
+The existing Core release workflow already accepts canonical bracketed headings such as `## [1.1.3] - YYYY-MM-DD` when extracting GitHub release notes.

--- a/docs/development/changelog-automation.md
+++ b/docs/development/changelog-automation.md
@@ -44,7 +44,9 @@ Dependabot YouTrack Ticket
 
 The prerequisite reads the current PR title, creates the YouTrack issue when no `RS-<number>` is present, and updates the title. `Require RS ticket` then reads the title again before validating it.
 
-The Dependabot target branch is synchronized weekly. The highest stable semantic-version branch is selected when one exists; otherwise the configuration falls back to `main`.
+The Dependabot target branch is synchronized weekly. The workflow reads `ModuleVersion` from `origin/main:RenderKit.psd1` and selects the highest stable semantic-version branch whose version is greater than the version currently declared on `main`. Once a release has been squash-merged and `main` declares that version, the old release branch is ignored even if it still exists remotely. If no newer release branch exists, Dependabot targets `main`.
+
+This version-based rule is intentionally used instead of Git ancestry because squash-merging a release branch does not make the release-branch head an ancestor of `main`.
 
 Required repository configuration:
 
@@ -114,7 +116,7 @@ When `CHANGELOG.md` changes, GitHub Actions creates a commit similar to:
 chore(changelog): RS-1129 update Unreleased [skip changelog]
 ```
 
-The `[skip changelog]` marker prevents an automation loop.
+The `[skip changelog]` marker suppresses generation of a change entry for automation-only commits. Structural normalization still runs, so an accidentally reverted Keep a Changelog header or version-heading syntax can be repaired without producing a duplicate release-note entry.
 
 ## Cutting a release
 

--- a/docs/public-functions.md
+++ b/docs/public-functions.md
@@ -91,6 +91,7 @@ See the [metadata workflow](metadata.md) for state and adapter semantics.
 | `Test-BackupConfigProfile` | Validate stored, imported, or draft profile data. |
 | `Export-BackupConfigProfile` | Export a user profile. |
 | `Import-BackupConfigProfile` | Import a profile with explicit conflict behavior. |
+| `Get-BackupWorkerCapability` | Inspect the hardware and encoder capabilities reported by backup workers. |
 | `Get-BackupAdapter` | Query registered backup adapters. |
 | `Register-BackupAdapter` | Register a trusted adapter implementation. |
 | `Remove-BackupAdapter` | Remove registered adapters. |

--- a/scripts/Check-ChangelogScope.mjs
+++ b/scripts/Check-ChangelogScope.mjs
@@ -1,0 +1,35 @@
+import { appendFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { versionBranchPattern } from './Validate-ChangeTicket.mjs';
+
+export function requiresChangelog(messageValue) {
+  const subject = (messageValue || '').split(/\r?\n/u, 1)[0].trim();
+  const sourceTitle = subject.replace(/\s+\(#\d+\)\s*$/u, '').trim();
+
+  return !versionBranchPattern.test(sourceTitle);
+}
+
+async function main() {
+  const required = requiresChangelog(process.env.COMMIT_MESSAGE);
+
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `required=${String(required)}\n`,
+      'utf8',
+    );
+  }
+
+  console.log(
+    required
+      ? 'The pushed commit requires changelog processing.'
+      : 'Skipping changelog processing for a version-only squash commit.',
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/Test-ChangelogScope.mjs
+++ b/scripts/Test-ChangelogScope.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { requiresChangelog } from './Check-ChangelogScope.mjs';
+
+assert.equal(requiresChangelog('1.1.3'), false);
+assert.equal(requiresChangelog('1.1.3 (#81)'), false);
+assert.equal(requiresChangelog('1.1.3-rc1'), false);
+assert.equal(requiresChangelog('1.1.3-rc12 (#81)'), false);
+assert.equal(requiresChangelog('Release 1.1.3 (#81)'), true);
+assert.equal(requiresChangelog('v1.1.3 (#81)'), true);
+assert.equal(
+  requiresChangelog('fix(changelog): RS-1404 retain ticket validation'),
+  true,
+);
+
+console.log('Changelog scope rules passed.');

--- a/scripts/Test-ValidateChangeTicket.mjs
+++ b/scripts/Test-ValidateChangeTicket.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import {
+  validateChangeTicket,
+  versionBranchPattern,
+} from './Validate-ChangeTicket.mjs';
+
+assert.equal(versionBranchPattern.test('1.1.3'), true);
+assert.equal(versionBranchPattern.test('1.1.3-rc1'), true);
+assert.equal(versionBranchPattern.test('1.1.3-rc12'), true);
+assert.equal(versionBranchPattern.test('release/1.1.3'), false);
+assert.equal(versionBranchPattern.test('v1.1.3'), false);
+assert.equal(versionBranchPattern.test('1.1.3-rc'), false);
+
+assert.deepEqual(validateChangeTicket('1.1.3', '1.1.3'), {
+  exempt: true,
+  headRef: '1.1.3',
+  ticket: null,
+});
+
+assert.deepEqual(validateChangeTicket('Release candidate', '1.1.3-rc12'), {
+  exempt: true,
+  headRef: '1.1.3-rc12',
+  ticket: null,
+});
+
+assert.equal(
+  validateChangeTicket(
+    'fix(changelog): RS-1404 retain ticket validation',
+    'fix/RS-1404-ticket-validation',
+  ).ticket,
+  'RS-1404',
+);
+
+assert.throws(
+  () => validateChangeTicket('Release 1.1.3', 'release/1.1.3'),
+  /must contain an RS ticket/u,
+);
+
+assert.throws(
+  () => validateChangeTicket('Fix validation', 'fix/ticket-validation'),
+  /must contain an RS ticket/u,
+);
+
+console.log('Ticket validation rules passed.');

--- a/scripts/Update-Changelog.mjs
+++ b/scripts/Update-Changelog.mjs
@@ -1,0 +1,379 @@
+import { appendFile, readFile, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+
+const CHANGELOG_PATH = process.env.CHANGELOG_PATH || 'CHANGELOG.md';
+const BEFORE_SHA = process.env.BEFORE_SHA || '';
+const AFTER_SHA = process.env.AFTER_SHA || 'HEAD';
+const ZERO_SHA = /^0+$/;
+const TICKET_PATTERN = /\bRS-\d+\b/gi;
+const SKIP_PATTERN = /\[skip changelog\]/i;
+const CATEGORY_ORDER = ['Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security'];
+
+function runGit(args) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 8 * 1024 * 1024,
+  }).trimEnd();
+}
+
+function parseCommits(raw) {
+  return raw
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [sha = '', subject = '', body = '', authorEmail = ''] = record.split('\x1f');
+      return {
+        sha,
+        subject: subject.trim(),
+        body: body.trim(),
+        authorEmail: authorEmail.trim(),
+      };
+    });
+}
+
+function loadCommits() {
+  const format = '%H%x1f%s%x1f%b%x1f%ae%x1e';
+  const after = AFTER_SHA || 'HEAD';
+  const hasBefore = BEFORE_SHA && !ZERO_SHA.test(BEFORE_SHA);
+
+  try {
+    if (hasBefore) {
+      return parseCommits(
+        runGit(['log', '--reverse', `--format=${format}`, `${BEFORE_SHA}..${after}`]),
+      );
+    }
+    return parseCommits(runGit(['show', '-s', `--format=${format}`, after]));
+  } catch (error) {
+    if (!hasBefore) {
+      throw error;
+    }
+    console.warn('Commit range was unavailable; evaluating the pushed head commit only.');
+    return parseCommits(runGit(['show', '-s', `--format=${format}`, after]));
+  }
+}
+
+function uniqueTickets(text) {
+  return [...new Set(
+    (text.match(TICKET_PATTERN) || []).map((ticket) => ticket.toUpperCase()),
+  )];
+}
+
+function categoryFor(subject) {
+  const type = subject.match(/^([a-z]+)(?:\([^)]*\))?!?:\s*/i)?.[1]?.toLowerCase();
+
+  switch (type) {
+    case 'feat':
+      return 'Added';
+    case 'fix':
+      return 'Fixed';
+    case 'security':
+      return 'Security';
+    case 'remove':
+    case 'removed':
+      return 'Removed';
+    case 'deprecate':
+    case 'deprecated':
+      return 'Deprecated';
+    default:
+      return 'Changed';
+  }
+}
+
+function cleanDescription(subject) {
+  let description = subject
+    .replace(/^([a-z]+)(?:\([^)]*\))?!?:\s*/i, '')
+    .replace(TICKET_PATTERN, '')
+    .replace(/^\s*[-:–—]+\s*/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!description) {
+    return '';
+  }
+
+  description = description[0].toUpperCase() + description.slice(1);
+  return description.replace(/[.;:,]+$/, '');
+}
+
+function isWeakDescription(description) {
+  if (description.length < 18) {
+    return true;
+  }
+
+  return /^(update|changes?|misc|work|wip|cleanup|adjustments?|improvements?|fix(?:es)?|stuff)(?:\s+.*)?$/i
+    .test(description);
+}
+
+function commitDiff(sha) {
+  try {
+    return runGit([
+      'show',
+      '--format=',
+      '--unified=1',
+      '--no-ext-diff',
+      sha,
+    ]).slice(0, 12000);
+  } catch {
+    return '';
+  }
+}
+
+function extractResponseText(payload) {
+  if (typeof payload.output_text === 'string') {
+    return payload.output_text.trim();
+  }
+
+  const parts = [];
+  for (const item of payload.output || []) {
+    for (const content of item.content || []) {
+      if (typeof content.text === 'string') {
+        parts.push(content.text);
+      }
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+async function improveDescription(commit, fallback) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey || !isWeakDescription(fallback)) {
+    return fallback;
+  }
+
+  const model = process.env.OPENAI_MODEL || 'gpt-5-mini';
+  const diff = commitDiff(commit.sha);
+  const input = [
+    'Write one concise Keep a Changelog bullet description in English.',
+    'Return only the description, without a bullet, ticket number, SHA, category, or Markdown.',
+    'Use past tense, describe user or developer impact, and do not invent behavior.',
+    '',
+    `Commit subject: ${commit.subject}`,
+    commit.body ? `Commit body: ${commit.body}` : '',
+    diff ? `Diff:\n${diff}` : '',
+  ].filter(Boolean).join('\n');
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        store: false,
+        input,
+        max_output_tokens: 100,
+      }),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!response.ok) {
+      console.warn(`OpenAI fallback returned HTTP ${response.status}; using the commit subject.`);
+      return fallback;
+    }
+
+    const text = extractResponseText(await response.json())
+      .replace(/^[-*]\s*/, '')
+      .replace(TICKET_PATTERN, '')
+      .replace(/\s*\([0-9a-f]{7,40}\)\s*$/i, '')
+      .replace(/^['"]|['"]$/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/[.;:,]+$/, '');
+
+    return text || fallback;
+  } catch (error) {
+    console.warn(
+      `OpenAI fallback was unavailable (${error.name || 'error'}); using the commit subject.`,
+    );
+    return fallback;
+  }
+}
+
+function keepAChangelogHeader() {
+  return [
+    '# Changelog',
+    '',
+    'All notable changes to this project will be documented in this file.',
+    '',
+    'The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),',
+    'and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).',
+    '',
+    '',
+  ].join('\n');
+}
+
+function unreleasedTemplate() {
+  return [
+    '## [Unreleased]',
+    '',
+    ...CATEGORY_ORDER.flatMap((category) => [`### ${category}`, '']),
+  ].join('\n').trimEnd();
+}
+
+function normalizeVersionHeadings(content) {
+  return content.replace(
+    /^##\s+(?!\[)(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\s+-\s+/gm,
+    '## [$1] - ',
+  );
+}
+
+function normalizeChangelog(original) {
+  let content = original.replace(/\r\n/g, '\n').trimEnd();
+  content = content ? `${content}\n` : keepAChangelogHeader();
+  content = normalizeVersionHeadings(content);
+
+  if (!content.startsWith('# Changelog')) {
+    content = `${keepAChangelogHeader()}${content.replace(/^\s+/, '')}`;
+  } else if (!content.includes('Keep a Changelog')) {
+    content = content.replace(/^# Changelog\s*\n/, keepAChangelogHeader());
+  }
+
+  if (!/^## \[Unreleased\][ \t]*$/m.test(content)) {
+    const firstVersion = content.search(/^## \[[^\]]+\](?:\s+-\s+.*)?$/m);
+    const block = `${unreleasedTemplate()}\n\n`;
+
+    if (firstVersion >= 0) {
+      content = `${content.slice(0, firstVersion)}${block}${content.slice(firstVersion)}`;
+    } else {
+      content = `${content.trimEnd()}\n\n${block}`;
+    }
+  }
+
+  const unreleasedStart = content.search(/^## \[Unreleased\][ \t]*$/m);
+  const headingEnd = content.indexOf('\n', unreleasedStart);
+  const nextVersionRelative = content.slice(headingEnd + 1).search(/^## /m);
+  const unreleasedEnd = nextVersionRelative >= 0
+    ? headingEnd + 1 + nextVersionRelative
+    : content.length;
+
+  let block = content.slice(unreleasedStart, unreleasedEnd).trimEnd();
+  for (const category of CATEGORY_ORDER) {
+    if (!new RegExp(`^### ${category}[ \t]*$`, 'm').test(block)) {
+      block += `\n\n### ${category}`;
+    }
+  }
+
+  const remainder = content.slice(unreleasedEnd).replace(/^\s+/, '');
+  return `${content.slice(0, unreleasedStart)}${block}\n\n${remainder}`.trimEnd() + '\n';
+}
+
+function addEntry(content, category, entry, shortSha) {
+  if (content.includes(`(\`${shortSha}\`)`)) {
+    return { content, added: false };
+  }
+
+  const unreleasedStart = content.search(/^## \[Unreleased\][ \t]*$/m);
+  const headingEnd = content.indexOf('\n', unreleasedStart);
+  const nextVersionRelative = content.slice(headingEnd + 1).search(/^## /m);
+  const unreleasedEnd = nextVersionRelative >= 0
+    ? headingEnd + 1 + nextVersionRelative
+    : content.length;
+  const block = content.slice(unreleasedStart, unreleasedEnd);
+
+  const sectionPattern = new RegExp(`(^### ${category}[ \\t]*$\\n)`, 'm');
+  const match = sectionPattern.exec(block);
+  if (!match) {
+    throw new Error(`Missing Unreleased category: ${category}`);
+  }
+
+  const insertAt = unreleasedStart + match.index + match[0].length;
+  const remainder = content.slice(insertAt).replace(/^\n+/, '');
+  const separator = remainder.startsWith('- ') ? '\n' : '\n\n';
+  return {
+    content: `${content.slice(0, insertAt)}\n${entry}${separator}${remainder}`,
+    added: true,
+  };
+}
+
+async function writeOutputs(values) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  const lines = Object.entries(values)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  await appendFile(process.env.GITHUB_OUTPUT, `${lines}\n`, 'utf8');
+}
+
+async function main() {
+  const commits = loadCommits().filter((commit) => {
+    const message = `${commit.subject}\n${commit.body}`;
+    return !SKIP_PATTERN.test(message)
+      && !/github-actions\[bot\]/i.test(commit.authorEmail);
+  });
+
+  if (commits.length === 0) {
+    console.log('No changelog-relevant commits found.');
+    await writeOutputs({ changed: 'false', tickets: '', entries: '0' });
+    return;
+  }
+
+  const missingTickets = commits.filter(
+    (commit) => uniqueTickets(`${commit.subject}\n${commit.body}`).length === 0,
+  );
+  if (missingTickets.length > 0) {
+    const list = missingTickets
+      .map((commit) => `- ${commit.sha.slice(0, 7)} ${commit.subject}`)
+      .join('\n');
+    throw new Error(`Every change must reference an RS ticket. Missing ticket:\n${list}`);
+  }
+
+  let original = '';
+  try {
+    original = await readFile(CHANGELOG_PATH, 'utf8');
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  let content = normalizeChangelog(original);
+  const allTickets = new Set();
+  let addedCount = 0;
+
+  for (const commit of commits) {
+    const tickets = uniqueTickets(`${commit.subject}\n${commit.body}`);
+    tickets.forEach((ticket) => allTickets.add(ticket));
+
+    const ticket = tickets[0];
+    const shortSha = commit.sha.slice(0, 7);
+    const fallback = cleanDescription(commit.subject) || `Updated ${ticket}`;
+    const description = await improveDescription(commit, fallback);
+    const sentence = /[.!?]$/.test(description) ? description : `${description}.`;
+    const entry = `- **${ticket}:** ${sentence} (\`${shortSha}\`)`;
+
+    const result = addEntry(content, categoryFor(commit.subject), entry, shortSha);
+    content = result.content;
+    if (result.added) {
+      addedCount += 1;
+    }
+  }
+
+  const normalizedOriginal = original.replace(/\r\n/g, '\n');
+  const changed = content !== normalizedOriginal;
+  if (changed) {
+    await writeFile(CHANGELOG_PATH, content, 'utf8');
+  }
+
+  await writeOutputs({
+    changed: String(changed),
+    tickets: [...allTickets].join(','),
+    entries: String(addedCount),
+  });
+
+  console.log(
+    changed
+      ? `Updated ${CHANGELOG_PATH} with ${addedCount} new entr${addedCount === 1 ? 'y' : 'ies'}.`
+      : 'Changelog is already current.',
+  );
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});

--- a/scripts/Update-Changelog.mjs
+++ b/scripts/Update-Changelog.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 const CHANGELOG_PATH = process.env.CHANGELOG_PATH || 'CHANGELOG.md';
 const BEFORE_SHA = process.env.BEFORE_SHA || '';
 const AFTER_SHA = process.env.AFTER_SHA || 'HEAD';
+const PROCESS_ENTRIES = !/^(?:false|0|no)$/i.test(process.env.PROCESS_ENTRIES || 'true');
 const ZERO_SHA = /^0+$/;
 const TICKET_PATTERN = /\bRS-\d+\b/gi;
 const SKIP_PATTERN = /\[skip changelog\]/i;
@@ -301,15 +302,38 @@ async function writeOutputs(values) {
 }
 
 async function main() {
-  const commits = loadCommits().filter((commit) => {
-    const message = `${commit.subject}\n${commit.body}`;
-    return !SKIP_PATTERN.test(message)
-      && !/github-actions\[bot\]/i.test(commit.authorEmail);
-  });
+  const commits = PROCESS_ENTRIES
+    ? loadCommits().filter((commit) => {
+        const message = `${commit.subject}\n${commit.body}`;
+        return !SKIP_PATTERN.test(message)
+          && !/github-actions\[bot\]/i.test(commit.authorEmail);
+      })
+    : [];
+
+  let original = '';
+  try {
+    original = await readFile(CHANGELOG_PATH, 'utf8');
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  let content = normalizeChangelog(original);
 
   if (commits.length === 0) {
-    console.log('No changelog-relevant commits found.');
-    await writeOutputs({ changed: 'false', tickets: '', entries: '0' });
+    const normalizedOriginal = original.replace(/\r\n/g, '\n');
+    const changed = content !== normalizedOriginal;
+    if (changed) {
+      await writeFile(CHANGELOG_PATH, content, 'utf8');
+    }
+
+    await writeOutputs({ changed: String(changed), tickets: '', entries: '0' });
+    console.log(
+      changed
+        ? `Normalized ${CHANGELOG_PATH} without adding a change entry.`
+        : 'No changelog-relevant commits found and changelog structure is current.',
+    );
     return;
   }
 
@@ -323,16 +347,6 @@ async function main() {
     throw new Error(`Every change must reference an RS ticket. Missing ticket:\n${list}`);
   }
 
-  let original = '';
-  try {
-    original = await readFile(CHANGELOG_PATH, 'utf8');
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  let content = normalizeChangelog(original);
   const allTickets = new Set();
   let addedCount = 0;
 

--- a/scripts/Validate-ChangeTicket.mjs
+++ b/scripts/Validate-ChangeTicket.mjs
@@ -1,0 +1,59 @@
+import { pathToFileURL } from 'node:url';
+
+const ticketPattern = /\bRS-\d+\b/i;
+export const versionBranchPattern = /^\d+\.\d+\.\d+(?:-rc\d+)?$/i;
+
+export function validateChangeTicket(titleValue, headRefValue) {
+  const title = (titleValue || '').trim();
+  const headRef = (headRefValue || '').trim();
+
+  if (versionBranchPattern.test(headRef)) {
+    return {
+      exempt: true,
+      headRef,
+      ticket: null,
+    };
+  }
+
+  if (!title) {
+    throw new Error('Pull request title is unavailable.');
+  }
+
+  const ticket = title.match(ticketPattern)?.[0]?.toUpperCase();
+  if (!ticket) {
+    throw new Error(
+      'Pull request title must contain an RS ticket, for example RS-1404.',
+    );
+  }
+
+  return {
+    exempt: false,
+    headRef,
+    ticket,
+  };
+}
+
+function main() {
+  try {
+    const result = validateChangeTicket(
+      process.env.PR_TITLE,
+      process.env.PR_HEAD_REF,
+    );
+
+    if (result.exempt) {
+      console.log(
+        `Version branch ${result.headRef} is exempt from RS ticket validation.`,
+      );
+      return;
+    }
+
+    console.log(`Validated change ticket ${result.ticket} in the pull request title.`);
+  } catch (error) {
+    console.error(error.message || error);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/src/Private/Backup/RenderKit.BackupGpuDetectionService.ps1
+++ b/src/Private/Backup/RenderKit.BackupGpuDetectionService.ps1
@@ -134,6 +134,88 @@ function Get-BackupFfmpegEncoderNameList {
     }
 }
 
+function Test-BackupFfmpegEncoderCapability {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FfmpegPath,
+        [Parameter(Mandatory)]
+        [string]$EncoderName,
+        [ValidateRange(1, 60)]
+        [int]$TimeoutSeconds = 15
+    )
+
+    $processInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $processInfo.FileName = $FfmpegPath
+    $processInfo.UseShellExecute = $false
+    $processInfo.RedirectStandardOutput = $true
+    $processInfo.RedirectStandardError = $true
+    $processInfo.CreateNoWindow = $true
+    foreach ($argument in @(
+            '-hide_banner',
+            '-loglevel', 'error',
+            '-f', 'lavfi',
+            '-i', 'color=c=black:s=640x360:d=0.1',
+            '-frames:v', '1',
+            '-an',
+            '-c:v', $EncoderName,
+            '-f', 'null',
+            '-')) {
+        $processInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $processInfo
+    try {
+        [void]$process.Start()
+        $standardOutput = $process.StandardOutput.ReadToEndAsync()
+        $standardError = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+            $process.Kill($true)
+            $process.WaitForExit()
+            return [PSCustomObject]@{
+                encoderName = $EncoderName
+                usable = $false
+                exitCode = $null
+                reason = 'ProbeTimedOut'
+                error = "Encoder probe exceeded $TimeoutSeconds second(s)."
+            }
+        }
+
+        $outputText = $standardOutput.GetAwaiter().GetResult()
+        $errorText = $standardError.GetAwaiter().GetResult()
+        return [PSCustomObject]@{
+            encoderName = $EncoderName
+            usable = $process.ExitCode -eq 0
+            exitCode = [int]$process.ExitCode
+            reason = if ($process.ExitCode -eq 0) {
+                'ProbeSucceeded'
+            }
+            else {
+                'ProbeFailed'
+            }
+            error = if ([string]::IsNullOrWhiteSpace($errorText)) {
+                $outputText
+            }
+            else {
+                $errorText
+            }
+        }
+    }
+    catch {
+        return [PSCustomObject]@{
+            encoderName = $EncoderName
+            usable = $false
+            exitCode = $null
+            reason = 'ProbeFailed'
+            error = $_.Exception.Message
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
 function Get-BackupVideoControllerNameList {
     [CmdletBinding()]
     param()
@@ -190,6 +272,7 @@ function New-BackupGpuCapabilityReport {
         [ValidateRange(1, 8760)]
         [int]$CacheTtlHours = 168,
         [string]$Source = 'Provided',
+        [hashtable]$EncoderProbeResults,
         [switch]$RunBenchmark
     )
 
@@ -226,12 +309,32 @@ function New-BackupGpuCapabilityReport {
         foreach ($codec in @('H264', 'H265', 'AV1')) {
             $encoder = [string](Get-BackupGpuObjectValue -InputObject $definition.encoders -Name $codec)
             $ffmpegSupported = $normalizedEncoderNames -contains $encoder.ToLowerInvariant()
+            $probeKnown = $null -ne $EncoderProbeResults -and
+                $EncoderProbeResults.ContainsKey($encoder)
+            $probeSucceeded = $probeKnown -and
+                [bool]$EncoderProbeResults[$encoder].usable
             $codecCapabilities[$codec] = [PSCustomObject]@{
                 codec          = $codec
                 encoderName    = $encoder
                 ffmpegSupported = [bool]$ffmpegSupported
                 hardwareDetected = [bool]$hardwareDetected
-                usableForAuto = [bool]($ffmpegSupported -and $hardwareDetected)
+                probeKnown     = [bool]$probeKnown
+                probeSucceeded = if ($probeKnown) {
+                    [bool]$probeSucceeded
+                }
+                else {
+                    $null
+                }
+                probeReason    = if ($probeKnown) {
+                    [string]$EncoderProbeResults[$encoder].reason
+                }
+                else {
+                    $null
+                }
+                usableForAuto = [bool](
+                    $ffmpegSupported -and
+                    $hardwareDetected -and
+                    (-not $RunBenchmark -or $probeSucceeded))
             }
         }
 
@@ -289,7 +392,7 @@ function New-BackupGpuCapabilityReport {
 
     $detectedAtUtc = (Get-Date).ToUniversalTime()
     return [PSCustomObject]@{
-        schemaVersion = '1.0'
+        schemaVersion = '1.1'
         source        = $Source
         detectedAtUtc = $detectedAtUtc.ToString('o')
         expiresAtUtc  = $detectedAtUtc.AddHours($CacheTtlHours).ToString('o')
@@ -307,9 +410,15 @@ function New-BackupGpuCapabilityReport {
         recommendations = [PSCustomObject]$recommendations
         benchmark     = [PSCustomObject]@{
             requested = [bool]$RunBenchmark
-            state     = if ($RunBenchmark) { 'Planned' } else { 'NotRun' }
+            state     = if ($RunBenchmark) { 'Completed' } else { 'NotRun' }
             mode      = 'CapabilityCacheMicroBenchmark'
-            reason    = if ($RunBenchmark) { 'Benchmark can be run by a worker without blocking planning.' } else { 'Capability detection does not run encode benchmarks by default.' }
+            reason    = if ($RunBenchmark) { 'Hardware encoders were validated with a one-frame capability probe.' } else { 'Capability detection did not run encode probes.' }
+            results   = if ($null -ne $EncoderProbeResults) {
+                [PSCustomObject]$EncoderProbeResults
+            }
+            else {
+                [PSCustomObject]@{}
+            }
         }
         cache         = [PSCustomObject]@{
             enabled  = $true
@@ -373,6 +482,9 @@ function Read-BackupGpuCapabilityCache {
     try {
         $report = Get-Content -LiteralPath $Path -Raw -ErrorAction Stop |
             ConvertFrom-Json -ErrorAction Stop
+        if ([string]$report.schemaVersion -ne '1.1') {
+            return $null
+        }
         $expiresAtText = [string](Get-BackupGpuObjectValue -InputObject $report -Name 'expiresAtUtc')
         $expiresAt = [datetime]::MinValue
         $isExpired = -not [datetime]::TryParse(
@@ -429,6 +541,39 @@ function Get-BackupGpuCapabilityReport {
         }
     )
 
+    $detectedReport = New-BackupGpuCapabilityReport `
+        -EncoderNames @($encoderNames) `
+        -VideoControllerNames @($controllerNames) `
+        -DetectedCommands @($detectedCommands) `
+        -FfmpegPath $ffmpegPath `
+        -CachePath $cachePath `
+        -CacheTtlHours $CacheTtlHours `
+        -Source 'Live'
+
+    $probeResults = @{}
+    if (-not [string]::IsNullOrWhiteSpace($ffmpegPath)) {
+        foreach ($provider in @($detectedReport.providers |
+                Where-Object { [bool]$_.hardwareDetected })) {
+            foreach ($codec in @('H264', 'H265', 'AV1')) {
+                $capability = Get-BackupGpuObjectValue `
+                    -InputObject $provider.codecCapabilities `
+                    -Name $codec
+                if (-not $capability -or
+                    -not [bool]$capability.ffmpegSupported) {
+                    continue
+                }
+                $encoderName = [string]$capability.encoderName
+                if ($probeResults.ContainsKey($encoderName)) {
+                    continue
+                }
+                $probeResults[$encoderName] =
+                    Test-BackupFfmpegEncoderCapability `
+                        -FfmpegPath $ffmpegPath `
+                        -EncoderName $encoderName
+            }
+        }
+    }
+
     $report = New-BackupGpuCapabilityReport `
         -EncoderNames @($encoderNames) `
         -VideoControllerNames @($controllerNames) `
@@ -437,7 +582,8 @@ function Get-BackupGpuCapabilityReport {
         -CachePath $cachePath `
         -CacheTtlHours $CacheTtlHours `
         -Source 'Live' `
-        -RunBenchmark:$RunBenchmark
+        -EncoderProbeResults $probeResults `
+        -RunBenchmark
 
     if (-not $SkipCacheWrite) {
         Save-BackupGpuCapabilityCache -Report $report -Path $cachePath | Out-Null

--- a/src/Private/Backup/RenderKit.BackupWorkerCapabilityService.ps1
+++ b/src/Private/Backup/RenderKit.BackupWorkerCapabilityService.ps1
@@ -1,0 +1,212 @@
+function Get-BackupWorkerCapabilitySnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkerId,
+        [switch]$Refresh
+    )
+
+    $gpu = Get-BackupGpuCapabilityReport -Refresh:$Refresh
+    $encoderNames = @(
+        @($gpu.ffmpeg.encoderNames) |
+            ForEach-Object { ([string]$_).ToLowerInvariant() }
+    )
+    $cpuCodecs = @(
+        foreach ($codec in @('H264', 'H265', 'AV1')) {
+            $encoderName = Get-BackupCpuEncoderName -VideoCodec $codec
+            if ($encoderNames -contains $encoderName.ToLowerInvariant()) {
+                $codec
+            }
+        }
+    )
+    $devices = New-Object System.Collections.Generic.List[object]
+    $devices.Add([PSCustomObject]@{
+            id               = 'CPU'
+            displayName      = 'CPU'
+            hardwareDetected = $true
+            codecs           = @($cpuCodecs)
+            encoderNames     = [PSCustomObject]@{
+                H264 = Get-BackupCpuEncoderName -VideoCodec H264
+                H265 = Get-BackupCpuEncoderName -VideoCodec H265
+                AV1  = Get-BackupCpuEncoderName -VideoCodec AV1
+            }
+        })
+    foreach ($provider in @($gpu.providers)) {
+        $devices.Add([PSCustomObject]@{
+                id               = [string]$provider.id
+                displayName      = [string]$provider.displayName
+                hardwareDetected = [bool]$provider.hardwareDetected
+                codecs           = @($provider.usableCodecs)
+                encoderNames     = [PSCustomObject]@{
+                    H264 = [string]$provider.codecCapabilities.H264.encoderName
+                    H265 = [string]$provider.codecCapabilities.H265.encoderName
+                    AV1  = [string]$provider.codecCapabilities.AV1.encoderName
+                }
+            })
+    }
+
+    return [PSCustomObject]@{
+        schemaVersion = '1.0'
+        workerId       = $WorkerId
+        machine        = [Environment]::MachineName
+        online         = $true
+        status         = 'Ready'
+        detectedAtUtc  = [string]$gpu.detectedAtUtc
+        expiresAtUtc   = [string]$gpu.expiresAtUtc
+        source         = [string]$gpu.source
+        runtime        = [PSCustomObject]@{
+            platform       = Get-RenderKitPlatform
+            processorCount = [Environment]::ProcessorCount
+            powerShell     = $PSVersionTable.PSVersion.ToString()
+        }
+        ffmpeg         = [PSCustomObject]@{
+            available = [bool]$gpu.ffmpeg.available
+            path      = [string]$gpu.ffmpeg.path
+        }
+        devices        = @($devices.ToArray())
+    }
+}
+
+function Test-BackupProfileWorkerCompatibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Settings,
+        [object[]]$WorkerCapability = @()
+    )
+
+    $resolvedCodec = Resolve-BackupVideoCodec `
+        -VideoCodec ([string]$Settings.VideoCodec) `
+        -CompressionPreset ([string]$Settings.CompressionPreset)
+    $requiresEncoding = [string]$Settings.CompressionMode -notin @(
+        'ArchiveOnly',
+        'CopyOnly'
+    )
+    $requestedDevice = [string]$Settings.EncoderDevice
+    $workers = New-Object System.Collections.Generic.List[object]
+
+    foreach ($capability in @($WorkerCapability)) {
+        $online = if (
+            $capability.PSObject.Properties.Name -contains 'online'
+        ) {
+            [bool]$capability.online
+        }
+        else {
+            $true
+        }
+        $compatible = $false
+        $resolvedDevice = $null
+        $reason = 'NoCompatibleEncoder'
+        $usesCpuFallback = $false
+
+        if (-not $online) {
+            $reason = 'WorkerOffline'
+        }
+        elseif (-not $requiresEncoding) {
+            $compatible = $true
+            $reason = 'NoEncodingRequired'
+        }
+        else {
+            $devices = @($capability.devices)
+            if ($requestedDevice -eq 'Auto') {
+                $hardware = @(
+                    $devices |
+                        Where-Object {
+                            [string]$_.id -ne 'CPU' -and
+                            @($_.codecs) -contains $resolvedCodec
+                        } |
+                        Select-Object -First 1
+                )
+                $cpu = @(
+                    $devices |
+                        Where-Object {
+                            [string]$_.id -eq 'CPU' -and
+                            @($_.codecs) -contains $resolvedCodec
+                        } |
+                        Select-Object -First 1
+                )
+                if ($hardware.Count -gt 0) {
+                    $compatible = $true
+                    $resolvedDevice = [string]$hardware[0].id
+                    $reason = 'HardwareEncoderAvailable'
+                }
+                elseif ($cpu.Count -gt 0) {
+                    $compatible = $true
+                    $resolvedDevice = 'CPU'
+                    $reason = 'CpuFallback'
+                    $usesCpuFallback = $true
+                }
+            }
+            else {
+                $requested = @(
+                    $devices |
+                        Where-Object {
+                            [string]$_.id -eq $requestedDevice -and
+                            @($_.codecs) -contains $resolvedCodec
+                        } |
+                        Select-Object -First 1
+                )
+                if ($requested.Count -gt 0) {
+                    $compatible = $true
+                    $resolvedDevice = $requestedDevice
+                    $reason = if ($requestedDevice -eq 'CPU') {
+                        'CpuEncoderAvailable'
+                    }
+                    else {
+                        'HardwareEncoderAvailable'
+                    }
+                }
+                else {
+                    $reason = 'RequestedDeviceUnavailable'
+                }
+            }
+        }
+
+        $workers.Add([PSCustomObject]@{
+                workerId       = [string]$capability.workerId
+                machine        = [string]$capability.machine
+                online         = $online
+                compatible     = $compatible
+                resolvedCodec  = $resolvedCodec
+                requestedDevice = $requestedDevice
+                resolvedDevice = $resolvedDevice
+                usesCpuFallback = $usesCpuFallback
+                reason         = $reason
+            })
+    }
+
+    $workerArray = @($workers.ToArray())
+    $onlineWorkers = @($workerArray | Where-Object { $_.online })
+    $compatibleWorkers = @(
+        $onlineWorkers | Where-Object { $_.compatible }
+    )
+    $fallbackWorkers = @(
+        $compatibleWorkers | Where-Object { $_.usesCpuFallback }
+    )
+    $status = if ($compatibleWorkers.Count -eq 0) {
+        'Unavailable'
+    }
+    elseif (
+        $compatibleWorkers.Count -lt $onlineWorkers.Count -or
+        $fallbackWorkers.Count -gt 0
+    ) {
+        'Degraded'
+    }
+    else {
+        'Available'
+    }
+
+    return [PSCustomObject]@{
+        schemaVersion       = '1.0'
+        status              = $status
+        isExecutable        = $compatibleWorkers.Count -gt 0
+        requiresEncoding    = $requiresEncoding
+        requestedCodec      = [string]$Settings.VideoCodec
+        resolvedCodec       = $resolvedCodec
+        requestedDevice     = $requestedDevice
+        compatibleWorkerIds = @(
+            $compatibleWorkers | ForEach-Object { [string]$_.workerId }
+        )
+        workers             = $workerArray
+    }
+}

--- a/src/Private/Job/RenderKit.WorkerDaemonService.ps1
+++ b/src/Private/Job/RenderKit.WorkerDaemonService.ps1
@@ -95,6 +95,7 @@ function New-RenderKitWorkerState {
         [string[]]$RecoveredJobIds = @(),
         [object]$LastTick,
         [object]$LastError,
+        [object]$Capabilities,
         [string]$StartedAtUtc
     )
 
@@ -123,6 +124,7 @@ function New-RenderKitWorkerState {
         recoveredJobIds = @($RecoveredJobIds)
         lastTick        = $LastTick
         lastError       = $LastError
+        capabilities    = $Capabilities
         logPath         = $LogPath
     }
 }
@@ -278,6 +280,9 @@ function Register-RenderKitWorkerCrashIfNeeded {
         -ProcessedCount ([int]$previous.processedCount) `
         -IdleTickCount ([int]$previous.idleTickCount) `
         -RecoveredJobIds @($previous.recoveredJobIds) `
+        -Capabilities $(if (
+            $previous.PSObject.Properties.Name -contains 'capabilities'
+        ) { $previous.capabilities } else { $null }) `
         -LastError ([PSCustomObject]@{
             message       = 'Previous worker process is no longer alive.'
             previousPid   = $previous.processId
@@ -418,6 +423,9 @@ function Get-RenderKitWorkerStatusSnapshot {
         recoveredJobIds = @($State.recoveredJobIds)
         lastTick       = $State.lastTick
         lastError      = $State.lastError
+        capabilities   = if (
+            $State.PSObject.Properties.Name -contains 'capabilities'
+        ) { $State.capabilities } else { $null }
         statePath      = Get-RenderKitWorkerStatePath -WorkerId ([string]$State.workerId)
         logPath        = $logPath
         logs           = if ($IncludeLogs) { @(Read-RenderKitWorkerLogTail -LogPath $logPath -Tail $Tail) } else { @() }
@@ -450,11 +458,22 @@ function Invoke-RenderKitLocalWorkerLoop {
         -JobType $JobType `
         -QueueName $QueueName `
         -LogPath $LogPath
+    $capabilityCommand = Get-Command `
+        -Name Get-BackupWorkerCapabilitySnapshot `
+        -CommandType Function `
+        -ErrorAction SilentlyContinue
+    $workerCapabilities = if ($capabilityCommand) {
+        Get-BackupWorkerCapabilitySnapshot -WorkerId $normalizedWorkerId
+    }
+    else {
+        $null
+    }
     $state = New-RenderKitWorkerState `
         -WorkerId $normalizedWorkerId `
         -JobType $JobType `
         -QueueName $QueueName `
         -LogPath $LogPath `
+        -Capabilities $workerCapabilities `
         -Status Running
     Save-RenderKitWorkerState -State $state | Out-Null
     Write-RenderKitWorkerLogEntry `
@@ -511,6 +530,7 @@ function Invoke-RenderKitLocalWorkerLoop {
                 -IdleTickCount $idleTickCount `
                 -RecoveredJobIds @($recoveredJobIds.ToArray()) `
                 -LastTick $tick `
+                -Capabilities $workerCapabilities `
                 -StartedAtUtc ([string]$state.startedAtUtc)
             Save-RenderKitWorkerState -State $state | Out-Null
 

--- a/src/Private/Project/RenderKit.ProjectExportService.ps1
+++ b/src/Private/Project/RenderKit.ProjectExportService.ps1
@@ -3,6 +3,85 @@ if ($PSVersionTable.PSVersion.Major -le 5) {
     Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
 } # Powershell 5.1 Support guard. T_T 
 
+function Get-RenderKitProjectExportFormat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('ManifestOnly', 'SelfContained')]
+        [string]$Mode
+    )
+
+    if ($null -eq $script:RenderKitFileFormatCatalog) {
+        $catalogPath = Join-Path `
+            -Path $script:RenderKitModuleRoot `
+            -ChildPath 'src/Resources/FileFormats/RenderKit.FileFormats.json'
+        if (-not (Test-Path -LiteralPath $catalogPath -PathType Leaf)) {
+            throw "RenderKit file format catalog '$catalogPath' was not found."
+        }
+        $script:RenderKitFileFormatCatalog = Get-Content `
+            -LiteralPath $catalogPath `
+            -Raw `
+            -Encoding UTF8 |
+            ConvertFrom-Json
+    }
+
+    $format = @($script:RenderKitFileFormatCatalog.formats |
+        Where-Object { [string]$_.exportMode -eq $Mode } |
+        Select-Object -First 1)
+    if ($format.Count -eq 0 -or
+        [string]::IsNullOrWhiteSpace([string]$format[0].extension)) {
+        throw "No RenderKit file format is registered for export mode '$Mode'."
+    }
+    return $format[0]
+}
+
+function Resolve-RenderKitProjectExportDestination {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$DestinationPath,
+        [Parameter(Mandatory)]
+        [ValidateSet('ManifestOnly', 'SelfContained')]
+        [string]$Mode
+    )
+
+    $format = Get-RenderKitProjectExportFormat -Mode $Mode
+    $requiredExtension = [string]$format.extension
+    $destinationIsDirectory = Test-Path `
+        -LiteralPath $DestinationPath `
+        -PathType Container
+    $trimmedDestination = $DestinationPath.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    if ($destinationIsDirectory -or
+        $trimmedDestination.Length -ne $DestinationPath.Length) {
+        $destinationDirectory = if ($destinationIsDirectory) {
+            (Resolve-Path `
+                -LiteralPath $DestinationPath `
+                -ErrorAction Stop).ProviderPath
+        }
+        else {
+            [System.IO.Path]::GetFullPath($trimmedDestination)
+        }
+        return Join-Path `
+            -Path $destinationDirectory `
+            -ChildPath ("{0}{1}" -f (
+                    Split-Path -Path $ProjectRoot -Leaf
+                ), $requiredExtension)
+    }
+
+    if ($DestinationPath.EndsWith(
+            $requiredExtension,
+            [System.StringComparison]::OrdinalIgnoreCase)) {
+        return '{0}{1}' -f $DestinationPath.Substring(
+            0,
+            $DestinationPath.Length - $requiredExtension.Length
+        ), $requiredExtension
+    }
+    return "$DestinationPath$requiredExtension"
+}
+
 function ConvertTo-RenderKitProjectRelativePath {
     [CmdletBinding()]
     param(

--- a/src/Public/Export-Project.ps1
+++ b/src/Public/Export-Project.ps1
@@ -26,30 +26,15 @@ Exports a RenderKit project manifest or self-contained project package.
         throw "Project root '$ProjectRoot' is not a directory."
     }
 
-    $destinationIsDirectory = Test-Path -LiteralPath $DestinationPath -PathType Container
-    $trimmedDestination = $DestinationPath.TrimEnd(
-        [System.IO.Path]::DirectorySeparatorChar,
-        [System.IO.Path]::AltDirectorySeparatorChar
-    )
-    if ($destinationIsDirectory -or $trimmedDestination.Length -ne $DestinationPath.Length) {
-        $destinationDirectory = if ($destinationIsDirectory) {
-            (Resolve-Path -LiteralPath $DestinationPath -ErrorAction Stop).ProviderPath
-        }
-        else {
-            [System.IO.Path]::GetFullPath($trimmedDestination)
-        }
-        $destinationExtension = if ($Mode -eq 'SelfContained') { '.rkitpkg' } else { '.rkit' }
-        $DestinationPath = Join-Path `
-            -Path $destinationDirectory `
-            -ChildPath ("{0}{1}" -f (Split-Path -Path $resolvedProjectRoot -Leaf), $destinationExtension)
-    }
-    
-    $extension = [System.IO.Path]::GetExtension($DestinationPath).ToLowerInvariant()
-    if ($Mode -eq 'ManifestOnly' -and $extension -ne '.rkit') {
-        Write-RenderKitLog -Level Warning -Message "ManifestOnly exports should use the .rkit extension."
-    }
-    if ($Mode -eq 'SelfContained' -and $extension -ne '.rkitpkg') {
-        Write-RenderKitLog -Level Warning -Message "SelfContained exports should use the .rkitpkg extension."
+    $requestedDestinationPath = $DestinationPath
+    $DestinationPath = Resolve-RenderKitProjectExportDestination `
+        -ProjectRoot $resolvedProjectRoot `
+        -DestinationPath $DestinationPath `
+        -Mode $Mode
+    if ($DestinationPath -cne $requestedDestinationPath) {
+        Write-RenderKitLog `
+            -Level Info `
+            -Message "Normalized project export destination to '$DestinationPath'."
     }
 
     if ($PSCmdlet.ShouldProcess($resolvedProjectRoot, "Export RenderKit project to '$DestinationPath'")) {

--- a/src/Public/Get-BackupWorkerCapability.ps1
+++ b/src/Public/Get-BackupWorkerCapability.ps1
@@ -1,0 +1,60 @@
+Register-RenderKitFunction 'Get-BackupWorkerCapability'
+function Get-BackupWorkerCapability {
+    <#
+.SYNOPSIS
+Returns execution capabilities for local and registered backup workers.
+
+.DESCRIPTION
+Each worker reports its own encoder capabilities. The returned array is
+designed for heterogeneous worker pools and includes offline registrations.
+#>
+    [CmdletBinding()]
+    param(
+        [string[]]$WorkerId,
+        [switch]$Refresh,
+        [switch]$OnlineOnly
+    )
+
+    $capabilities = [ordered]@{}
+    foreach ($state in @(Get-RenderKitWorkerStateList)) {
+        if (-not $state.capabilities -or
+            [string]::IsNullOrWhiteSpace([string]$state.workerId)) {
+            continue
+        }
+        $snapshot = $state.capabilities
+        $online = [string]$state.status -in @('Starting', 'Running', 'Idle') -and
+            (Test-RenderKitWorkerProcessAlive `
+                -ProcessId ([int]$state.processId) `
+                -MachineName ([string]$state.machine))
+        $snapshot | Add-Member `
+            -NotePropertyName online `
+            -NotePropertyValue ([bool]$online) `
+            -Force
+        $snapshot | Add-Member `
+            -NotePropertyName status `
+            -NotePropertyValue ([string]$state.status) `
+            -Force
+        $capabilities[[string]$state.workerId] = $snapshot
+    }
+
+    $localWorkerId = 'local-{0}' -f (
+        ConvertTo-RenderKitWorkerSafeName `
+            -Value ([Environment]::MachineName.ToLowerInvariant())
+    )
+    $capabilities[$localWorkerId] = Get-BackupWorkerCapabilitySnapshot `
+        -WorkerId $localWorkerId `
+        -Refresh:$Refresh
+
+    $result = @($capabilities.Values)
+    if ($WorkerId) {
+        $requested = @($WorkerId | ForEach-Object { [string]$_ })
+        $result = @(
+            $result |
+                Where-Object { $requested -contains [string]$_.workerId }
+        )
+    }
+    if ($OnlineOnly) {
+        $result = @($result | Where-Object { [bool]$_.online })
+    }
+    return @($result | Sort-Object workerId)
+}

--- a/src/Public/Start-RenderKitJobWorker.ps1
+++ b/src/Public/Start-RenderKitJobWorker.ps1
@@ -82,6 +82,8 @@ function Start-RenderKitJobWorker {
             -JobType $JobType `
             -QueueName $QueueName `
             -LogPath $LogPath `
+            -Capabilities (Get-BackupWorkerCapabilitySnapshot `
+                -WorkerId $normalizedWorkerId) `
             -Status Starting
         $state.processId = [int]$process.Id
         Save-RenderKitWorkerState -State $state | Out-Null

--- a/src/Public/Test-BackupConfigProfile.ps1
+++ b/src/Public/Test-BackupConfigProfile.ps1
@@ -18,7 +18,9 @@ Validates a built-in, stored, imported, or in-memory backup profile.
         [hashtable]$Settings = @{},
         [Parameter(ParameterSetName = 'Draft')]
         [string]$DraftName = 'studio-draft',
-        [switch]$CheckAdapters
+        [switch]$CheckAdapters,
+        [switch]$CheckHardware,
+        [object[]]$WorkerCapability
     )
 
     process {
@@ -54,17 +56,34 @@ Validates a built-in, stored, imported, or in-memory backup profile.
             $settingsValidation = Test-BackupConfigProfileSettings `
                 -Settings $profile.settings `
                 -CheckAdapters:$CheckAdapters
+            $executionCompatibility = if (
+                $CheckHardware -and $settingsValidation.normalizedSettings
+            ) {
+                $capabilities = if ($WorkerCapability) {
+                    @($WorkerCapability)
+                }
+                else {
+                    @(Get-BackupWorkerCapability)
+                }
+                Test-BackupProfileWorkerCompatibility `
+                    -Settings $settingsValidation.normalizedSettings `
+                    -WorkerCapability $capabilities
+            }
+            else {
+                $null
+            }
             return [PSCustomObject]@{
-                Name              = [string]$profile.name
-                Source            = 'BuiltIn'
-                Path              = $null
-                IsValid           = [bool]$settingsValidation.isValid
-                SchemaVersion     = [string]$profile.schemaVersion
-                ProfileVersion    = [string]$profile.profileVersion
-                Compatibility     = 'Current'
-                Errors            = @($settingsValidation.errors)
-                Warnings          = @($settingsValidation.warnings)
-                EffectiveSettings = $settingsValidation.normalizedSettings
+                Name                   = [string]$profile.name
+                Source                 = 'BuiltIn'
+                Path                   = $null
+                IsValid                = [bool]$settingsValidation.isValid
+                SchemaVersion          = [string]$profile.schemaVersion
+                ProfileVersion         = [string]$profile.profileVersion
+                Compatibility          = 'Current'
+                ExecutionCompatibility = $executionCompatibility
+                Errors                 = @($settingsValidation.errors)
+                Warnings               = @($settingsValidation.warnings)
+                EffectiveSettings      = $settingsValidation.normalizedSettings
             }
         }
 
@@ -73,31 +92,49 @@ Validates a built-in, stored, imported, or in-memory backup profile.
             $validation = Test-BackupConfigProfileDocumentDetailed `
                 -Profile $currentProfile `
                 -CheckAdapters:$CheckAdapters
+            $executionCompatibility = if (
+                $CheckHardware -and $validation.normalizedSettings
+            ) {
+                $capabilities = if ($WorkerCapability) {
+                    @($WorkerCapability)
+                }
+                else {
+                    @(Get-BackupWorkerCapability)
+                }
+                Test-BackupProfileWorkerCompatibility `
+                    -Settings $validation.normalizedSettings `
+                    -WorkerCapability $capabilities
+            }
+            else {
+                $null
+            }
             return [PSCustomObject]@{
-                Name              = [string]$currentProfile.name
-                Source            = $source
-                Path              = $sourcePath
-                IsValid           = [bool]$validation.isValid
-                SchemaVersion     = [string]$currentProfile.schemaVersion
-                ProfileVersion    = [string]$currentProfile.profileVersion
-                Compatibility     = if ($validation.compatibility) { [string]$validation.compatibility.Status } else { 'Unknown' }
-                Errors            = @($validation.errors)
-                Warnings          = @($validation.warnings)
-                EffectiveSettings = $validation.normalizedSettings
+                Name                   = [string]$currentProfile.name
+                Source                 = $source
+                Path                   = $sourcePath
+                IsValid                = [bool]$validation.isValid
+                SchemaVersion          = [string]$currentProfile.schemaVersion
+                ProfileVersion         = [string]$currentProfile.profileVersion
+                Compatibility          = if ($validation.compatibility) { [string]$validation.compatibility.Status } else { 'Unknown' }
+                ExecutionCompatibility = $executionCompatibility
+                Errors                 = @($validation.errors)
+                Warnings               = @($validation.warnings)
+                EffectiveSettings      = $validation.normalizedSettings
             }
         }
         catch {
             return [PSCustomObject]@{
-                Name              = if ($profile) { [string]$profile.name } else { $null }
-                Source            = $source
-                Path              = $sourcePath
-                IsValid           = $false
-                SchemaVersion     = if ($profile) { [string]$profile.schemaVersion } else { $null }
-                ProfileVersion    = if ($profile) { [string]$profile.profileVersion } else { $null }
-                Compatibility     = 'Invalid'
-                Errors            = @($_.Exception.Message)
-                Warnings          = @()
-                EffectiveSettings = $null
+                Name                   = if ($profile) { [string]$profile.name } else { $null }
+                Source                 = $source
+                Path                   = $sourcePath
+                IsValid                = $false
+                SchemaVersion          = if ($profile) { [string]$profile.schemaVersion } else { $null }
+                ProfileVersion         = if ($profile) { [string]$profile.profileVersion } else { $null }
+                Compatibility          = 'Invalid'
+                ExecutionCompatibility = $null
+                Errors                 = @($_.Exception.Message)
+                Warnings               = @()
+                EffectiveSettings      = $null
             }
         }
     }

--- a/src/Resources/FileFormats/RenderKit.FileFormats.json
+++ b/src/Resources/FileFormats/RenderKit.FileFormats.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "formats": [
+    {
+      "id": "project-manifest",
+      "displayName": "RenderKit Project Manifest",
+      "extension": ".rkit",
+      "exportMode": "ManifestOnly",
+      "container": "zip",
+      "mediaType": "application/vnd.renderkit.project+zip",
+      "fallbackMediaType": "application/zip",
+      "uniformTypeIdentifier": "com.conceptmarton.renderkit.project-manifest",
+      "windowsProgId": "RenderKit.ProjectManifest"
+    },
+    {
+      "id": "project-package",
+      "displayName": "RenderKit Project Package",
+      "extension": ".rkitpkg",
+      "exportMode": "SelfContained",
+      "container": "zip",
+      "mediaType": "application/vnd.renderkit.project-package+zip",
+      "fallbackMediaType": "application/zip",
+      "uniformTypeIdentifier": "com.conceptmarton.renderkit.project-package",
+      "windowsProgId": "RenderKit.ProjectPackage"
+    }
+  ]
+}


### PR DESCRIPTION
## Release: RenderKit 1.1.3

This release consolidates the current RenderKit Core changes for backup worker capability handling, hardware encoder selection, and canonical project archive exports.

## Included changes

- **RS-1129** — probe advertised hardware encoders with a real one-frame encode before automatic selection and safely fall back to CPU encoding when the GPU cannot execute the encoder
- **RS-798 / RS-799** — discover local and registered backup-worker capabilities and evaluate backup-profile compatibility per worker while preserving offline registrations
- **RS-1204** — define canonical RenderKit project archive formats and enforce `.rkit` / `.rkitpkg` export extensions

## Release infrastructure

- Keep a Changelog-compatible `Unreleased` / version-section automation
- RS-ticket validation for normal change PRs with semantic-version branch exemptions
- YouTrack state updates on PR close
- Dependabot for GitHub Actions with automatic active-release target selection
- GitHub-hosted changelog/ticket checks for the public Core repository
- pinned GitHub Actions release references instead of floating `@main` refs
- release workflow remains compatible with canonical `## [1.1.3] - YYYY-MM-DD` headings

## Version metadata

- `RenderKit.psd1` ModuleVersion: `1.1.3`
- PowerShell Gallery release notes updated for 1.1.3
- release branch: `1.1.3`
- target: `main`

## Validation before merge

- Quality Gate must pass
- changelog must be normalized to Keep a Changelog structure
- package build and PowerShell 7 / Windows PowerShell 5.1 validation must pass

After merge to `main`, the existing release workflow publishes the GitHub release, GitHub Package, PowerShell Gallery package, and post-publication Gallery validation.