### PR TITLE
RS-1508: Embedded-Runspace-Crash im Backup-Worker beheben

### DIFF
--- a/Tests/Backup/RenderKit.BackupEmbeddedRunspace.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupEmbeddedRunspace.Tests.ps1
@@ -1,0 +1,42 @@
+Describe 'RenderKit backup hosted-runspace compatibility' {
+    BeforeAll {
+        $repositoryRoot = Split-Path -Parent (
+            Split-Path -Parent $PSScriptRoot)
+        $module = Import-Module `
+            (Join-Path $repositoryRoot 'RenderKit.psd1') `
+            -PassThru `
+            -Force
+        $compatibilityPath = Join-Path `
+            $repositoryRoot `
+            'src/Private/Backup/RenderKit.BackupThreadJobHostCompatibility.ps1'
+        $compatibilitySource = Get-Content `
+            -LiteralPath $compatibilityPath `
+            -Raw
+    }
+
+    AfterAll {
+        Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'loads the hosted-runspace-safe thread-job implementation last' {
+        InModuleScope RenderKit {
+            $command = Get-Command `
+                -Name Start-BackupScheduledThreadJob `
+                -CommandType Function
+            Split-Path -Leaf $command.ScriptBlock.File |
+                Should -Be 'RenderKit.BackupThreadJobHostCompatibility.ps1'
+        }
+    }
+
+    It 'does not attach PowerShell scriptblocks to async process stderr events' {
+        $compatibilitySource | Should -Not -Match 'add_ErrorDataReceived'
+        $compatibilitySource | Should -Not -Match 'BeginErrorReadLine'
+        $compatibilitySource | Should -Match 'StandardError\.ReadToEndAsync\(\)'
+    }
+
+    It 'preserves stdout progress streaming while stderr is drained concurrently' {
+        $compatibilitySource | Should -Match 'StandardOutput\.ReadLine\(\)'
+        $compatibilitySource | Should -Match 'WaitForExit\(\)'
+        $compatibilitySource | Should -Match 'GetAwaiter\(\)\.GetResult\(\)'
+    }
+}

--- a/src/Private/Backup/RenderKit.BackupThreadJobHostCompatibility.ps1
+++ b/src/Private/Backup/RenderKit.BackupThreadJobHostCompatibility.ps1
@@ -1,0 +1,166 @@
+# RS-1508: Start-ThreadJob runs this worker in a hosted PowerShell runspace when
+# invoked by RenderKit Studio. Process.ErrorDataReceived callbacks are raised on
+# arbitrary .NET thread-pool threads; invoking a PowerShell scriptblock there can
+# terminate the broker with PSInvalidOperationException because no DefaultRunspace
+# exists on that callback thread. Keep stderr draining asynchronous, but do it
+# through StreamReader.ReadToEndAsync so no PowerShell delegate crosses threads.
+function Start-BackupScheduledThreadJob {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Command
+    )
+
+    Start-ThreadJob `
+        -Name ([string]$Command.id) `
+        -ArgumentList $Command `
+        -ScriptBlock {
+            param($ScheduledCommand)
+
+            function ConvertTo-BackupProcessArgumentText {
+                param([string[]]$Arguments)
+
+                $escaped = foreach ($argument in @($Arguments)) {
+                    if ($argument -match '[\s"]') {
+                        '"' + ($argument -replace '"', '\"') + '"'
+                    }
+                    else {
+                        $argument
+                    }
+                }
+
+                return ($escaped -join ' ')
+            }
+
+            $progressLogPath = if ($ScheduledCommand.progress -and $ScheduledCommand.progress.logPath) {
+                [string]$ScheduledCommand.progress.logPath
+            }
+            else {
+                $null
+            }
+            if (-not [string]::IsNullOrWhiteSpace($progressLogPath)) {
+                $progressFolder = Split-Path -Path $progressLogPath -Parent
+                if (-not [string]::IsNullOrWhiteSpace($progressFolder) -and
+                    -not (Test-Path -LiteralPath $progressFolder -PathType Container)) {
+                    New-Item -ItemType Directory -Path $progressFolder -Force | Out-Null
+                }
+                Set-Content -LiteralPath $progressLogPath -Value @() -Encoding UTF8
+            }
+
+            $pidPath = if ($ScheduledCommand.progress -and $ScheduledCommand.progress.pidPath) {
+                [string]$ScheduledCommand.progress.pidPath
+            }
+            else {
+                $null
+            }
+
+            $failureSimulation = if ($ScheduledCommand.PSObject.Properties.Name -contains 'failureSimulation') {
+                $ScheduledCommand.failureSimulation
+            }
+            else {
+                $null
+            }
+            $scenarios = @()
+            if ($failureSimulation -and $failureSimulation.PSObject.Properties.Name -contains 'scenarios') {
+                $scenarios = @($failureSimulation.scenarios | ForEach-Object { [string]$_ })
+            }
+            elseif ($failureSimulation -and $failureSimulation.PSObject.Properties.Name -contains 'scenario') {
+                $scenarios = @([string]$failureSimulation.scenario)
+            }
+            $failAttempts = if ($failureSimulation -and $failureSimulation.PSObject.Properties.Name -contains 'failAttempts') {
+                [Math]::Max(1, [int]$failureSimulation.failAttempts)
+            }
+            else {
+                1
+            }
+            $attempt = if ($ScheduledCommand.control -and $ScheduledCommand.control.PSObject.Properties.Name -contains 'attempts') {
+                [int]$ScheduledCommand.control.attempts
+            }
+            elseif ($ScheduledCommand.PSObject.Properties.Name -contains 'attempts') {
+                [int]$ScheduledCommand.attempts
+            }
+            else {
+                1
+            }
+            if ($failureSimulation -and
+                ($failureSimulation.PSObject.Properties.Name -notcontains 'enabled' -or [bool]$failureSimulation.enabled) -and
+                $scenarios -contains 'CorruptChunk' -and
+                $attempt -le $failAttempts) {
+                [PSCustomObject]@{
+                    commandId = [string]$ScheduledCommand.id
+                    processId = 0
+                    exitCode  = 23
+                    output    = @()
+                    error     = @("Simulated corrupt encoded chunk for command '$($ScheduledCommand.id)' on attempt $attempt.")
+                }
+                return
+            }
+
+            $processInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $processInfo.FileName = [string]$ScheduledCommand.executable
+            $processInfo.UseShellExecute = $false
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.CreateNoWindow = $true
+            try {
+                foreach ($argument in @($ScheduledCommand.arguments)) {
+                    $processInfo.ArgumentList.Add([string]$argument)
+                }
+            }
+            catch {
+                $processInfo.Arguments = ConvertTo-BackupProcessArgumentText -Arguments @($ScheduledCommand.arguments)
+            }
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $processInfo
+            try {
+                [void]$process.Start()
+                if (-not [string]::IsNullOrWhiteSpace($pidPath)) {
+                    $pidFolder = Split-Path -Path $pidPath -Parent
+                    if (-not [string]::IsNullOrWhiteSpace($pidFolder) -and
+                        -not (Test-Path -LiteralPath $pidFolder -PathType Container)) {
+                        New-Item -ItemType Directory -Path $pidFolder -Force | Out-Null
+                    }
+                    Set-Content -LiteralPath $pidPath -Value ([string]$process.Id) -Encoding UTF8
+                }
+
+                # Drain stderr concurrently without a PowerShell event delegate.
+                $standardErrorTask = $process.StandardError.ReadToEndAsync()
+
+                $lines = New-Object System.Collections.Generic.List[string]
+                while (-not $process.StandardOutput.EndOfStream) {
+                    $line = $process.StandardOutput.ReadLine()
+                    if ($null -eq $line) {
+                        continue
+                    }
+                    $lines.Add([string]$line)
+                    if (-not [string]::IsNullOrWhiteSpace($progressLogPath)) {
+                        Add-Content -LiteralPath $progressLogPath -Value ([string]$line) -Encoding UTF8
+                    }
+                }
+
+                $process.WaitForExit()
+                $standardError = $standardErrorTask.GetAwaiter().GetResult()
+                $errorLines = if ([string]::IsNullOrWhiteSpace([string]$standardError)) {
+                    @()
+                }
+                else {
+                    @(
+                        ([string]$standardError) -split "\r?\n" |
+                            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+                    )
+                }
+
+                [PSCustomObject]@{
+                    commandId = [string]$ScheduledCommand.id
+                    processId = [int]$process.Id
+                    exitCode  = [int]$process.ExitCode
+                    output    = @($lines.ToArray())
+                    error     = @($errorLines)
+                }
+            }
+            finally {
+                $process.Dispose()
+            }
+        }
+}


### PR DESCRIPTION
## Ticket

RS-1508

## Kontext

Follow-up zur bereits gemergten Studio-Supervision aus RS-1508. Der neue Fehler liegt nicht im Studio-Warmup, sondern im RenderKit-Core-Backup-Worker selbst.

Beim parallelen Backup-Encoding startet `Start-BackupScheduledThreadJob` einen externen Prozess und registriert für `Process.ErrorDataReceived` einen PowerShell-ScriptBlock als .NET-Event-Callback. `ErrorDataReceived` wird auf einem beliebigen ThreadPool-Thread ausgelöst. Im eingebetteten PowerShell-Host des RenderKit-Studio-Brokers besitzt dieser Thread keinen `DefaultRunspace`, wodurch eine unbehandelte `PSInvalidOperationException` den gesamten Broker beendet.

Typischer Fehler:

`There is no Runspace available to run scripts in this thread.`

Dadurch sieht Studio anschließend sekundäre Fehler wie `Broker closed the connection without a response` beziehungsweise vorübergehende Profil-/Storage-Fehler.

## Änderung

- hosted-runspace-sichere Implementierung von `Start-BackupScheduledThreadJob`
- kein PowerShell-ScriptBlock mehr an `Process.ErrorDataReceived`
- stderr wird stattdessen direkt über `StandardError.ReadToEndAsync()` parallel geleert
- stdout bleibt synchron gestreamt, damit FFmpeg-Progress unverändert verarbeitet und in die Progress-Datei geschrieben wird
- Prozess wird garantiert disposed
- Failure-Simulation, PID-Datei und Exit-/stderr-Rückgabe bleiben erhalten

## Regression

Zusätzliche Pester-Checks stellen sicher, dass:

- die hosted-runspace-sichere Implementierung tatsächlich die ursprüngliche Funktion überschreibt
- kein `add_ErrorDataReceived` / `BeginErrorReadLine` mehr verwendet wird
- stderr asynchron und stdout weiterhin progressfähig gelesen werden

## Scope

Keine Änderung an öffentlichen RenderKit-APIs. Der Fix betrifft ausschließlich die interne Prozessausführung des Backup-Workers.