### PR TITLE
RS-1508: Fix embedded backup worker runspace callback

### DIFF
--- a/Tests/Backup/RenderKit.BackupEmbeddedRunspace.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupEmbeddedRunspace.Tests.ps1
@@ -2,6 +2,13 @@ Describe 'RS-1508 embedded backup worker process handling' {
     BeforeAll {
         $repositoryRoot = Split-Path -Parent (
             Split-Path -Parent $PSScriptRoot)
+        $implementationPath = Join-Path `
+            $repositoryRoot `
+            'src/Private/Backup/RenderKit.BackupProcessExecution.ps1'
+        $implementationSource = Get-Content `
+            -LiteralPath $implementationPath `
+            -Raw
+
         Import-Module `
             (Join-Path $repositoryRoot 'RenderKit.psd1') `
             -Force
@@ -11,11 +18,15 @@ Describe 'RS-1508 embedded backup worker process handling' {
         Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
     }
 
+    It 'documents the ticket context on the hosted-runspace fix' {
+        $implementationSource | Should -Match 'RS-1508'
+        $implementationSource | Should -Match 'DefaultRunspace'
+    }
+
     It 'uses the hosted-runspace-safe backup worker implementation' {
         InModuleScope RenderKit {
             $definition = (Get-Command Start-BackupScheduledThreadJob).Definition
 
-            $definition | Should -Match 'RS-1508'
             $definition | Should -Not -Match 'add_ErrorDataReceived'
             $definition | Should -Not -Match 'BeginErrorReadLine'
             $definition | Should -Match 'StandardError\.ReadToEndAsync'

--- a/Tests/Backup/RenderKit.BackupEmbeddedRunspace.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupEmbeddedRunspace.Tests.ps1
@@ -1,0 +1,26 @@
+Describe 'RS-1508 embedded backup worker process handling' {
+    BeforeAll {
+        $repositoryRoot = Split-Path -Parent (
+            Split-Path -Parent $PSScriptRoot)
+        Import-Module `
+            (Join-Path $repositoryRoot 'RenderKit.psd1') `
+            -Force
+    }
+
+    AfterAll {
+        Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'uses the hosted-runspace-safe backup worker implementation' {
+        InModuleScope RenderKit {
+            $definition = (Get-Command Start-BackupScheduledThreadJob).Definition
+
+            $definition | Should -Match 'RS-1508'
+            $definition | Should -Not -Match 'add_ErrorDataReceived'
+            $definition | Should -Not -Match 'BeginErrorReadLine'
+            $definition | Should -Match 'StandardError\.ReadToEndAsync'
+            $definition | Should -Match 'StandardOutput\.ReadLine'
+            $definition | Should -Match '\$process\.Dispose\(\)'
+        }
+    }
+}

--- a/src/Private/Backup/RenderKit.BackupProcessExecution.ps1
+++ b/src/Private/Backup/RenderKit.BackupProcessExecution.ps1
@@ -1,0 +1,158 @@
+# RS-1508: Process.ErrorDataReceived invokes PowerShell script blocks on .NET
+# thread-pool threads that do not have a DefaultRunspace in embedded hosts.
+# Read redirected stderr directly instead so backup workers remain safe in hosted runspaces.
+function Start-BackupScheduledThreadJob {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Command
+    )
+
+    Start-ThreadJob `
+        -Name ([string]$Command.id) `
+        -ArgumentList $Command `
+        -ScriptBlock {
+            param($ScheduledCommand)
+
+            function ConvertTo-BackupProcessArgumentText {
+                param([string[]]$Arguments)
+
+                $escaped = foreach ($argument in @($Arguments)) {
+                    if ($argument -match '[\s"]') {
+                        '"' + ($argument -replace '"', '\"') + '"'
+                    }
+                    else {
+                        $argument
+                    }
+                }
+
+                return ($escaped -join ' ')
+            }
+
+            $progressLogPath = if ($ScheduledCommand.progress -and $ScheduledCommand.progress.logPath) {
+                [string]$ScheduledCommand.progress.logPath
+            }
+            else {
+                $null
+            }
+            if (-not [string]::IsNullOrWhiteSpace($progressLogPath)) {
+                $progressFolder = Split-Path -Path $progressLogPath -Parent
+                if (-not [string]::IsNullOrWhiteSpace($progressFolder) -and
+                    -not (Test-Path -LiteralPath $progressFolder -PathType Container)) {
+                    New-Item -ItemType Directory -Path $progressFolder -Force | Out-Null
+                }
+                Set-Content -LiteralPath $progressLogPath -Value @() -Encoding UTF8
+            }
+
+            $pidPath = if ($ScheduledCommand.progress -and $ScheduledCommand.progress.pidPath) {
+                [string]$ScheduledCommand.progress.pidPath
+            }
+            else {
+                $null
+            }
+
+            $failureSimulation = if ($ScheduledCommand.PSObject.Properties.Name -contains 'failureSimulation') {
+                $ScheduledCommand.failureSimulation
+            }
+            else {
+                $null
+            }
+            $scenarios = @()
+            if ($failureSimulation -and $failureSimulation.PSObject.Properties.Name -contains 'scenarios') {
+                $scenarios = @($failureSimulation.scenarios | ForEach-Object { [string]$_ })
+            }
+            elseif ($failureSimulation -and $failureSimulation.PSObject.Properties.Name -contains 'scenario') {
+                $scenarios = @([string]$failureSimulation.scenario)
+            }
+            $failAttempts = if ($failureSimulation -and $failureSimulation.PSObject.Properties.Name -contains 'failAttempts') {
+                [Math]::Max(1, [int]$failureSimulation.failAttempts)
+            }
+            else {
+                1
+            }
+            $attempt = if ($ScheduledCommand.control -and $ScheduledCommand.control.PSObject.Properties.Name -contains 'attempts') {
+                [int]$ScheduledCommand.control.attempts
+            }
+            elseif ($ScheduledCommand.PSObject.Properties.Name -contains 'attempts') {
+                [int]$ScheduledCommand.attempts
+            }
+            else {
+                1
+            }
+            if ($failureSimulation -and
+                ($failureSimulation.PSObject.Properties.Name -notcontains 'enabled' -or [bool]$failureSimulation.enabled) -and
+                $scenarios -contains 'CorruptChunk' -and
+                $attempt -le $failAttempts) {
+                [PSCustomObject]@{
+                    commandId = [string]$ScheduledCommand.id
+                    processId = 0
+                    exitCode  = 23
+                    output    = @()
+                    error     = @("Simulated corrupt encoded chunk for command '$($ScheduledCommand.id)' on attempt $attempt.")
+                }
+                return
+            }
+
+            $processInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $processInfo.FileName = [string]$ScheduledCommand.executable
+            $processInfo.UseShellExecute = $false
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.CreateNoWindow = $true
+            try {
+                foreach ($argument in @($ScheduledCommand.arguments)) {
+                    $processInfo.ArgumentList.Add([string]$argument)
+                }
+            }
+            catch {
+                $processInfo.Arguments = ConvertTo-BackupProcessArgumentText -Arguments @($ScheduledCommand.arguments)
+            }
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $processInfo
+            try {
+                [void]$process.Start()
+                if (-not [string]::IsNullOrWhiteSpace($pidPath)) {
+                    $pidFolder = Split-Path -Path $pidPath -Parent
+                    if (-not [string]::IsNullOrWhiteSpace($pidFolder) -and
+                        -not (Test-Path -LiteralPath $pidFolder -PathType Container)) {
+                        New-Item -ItemType Directory -Path $pidFolder -Force | Out-Null
+                    }
+                    Set-Content -LiteralPath $pidPath -Value ([string]$process.Id) -Encoding UTF8
+                }
+
+                $standardErrorTask = $process.StandardError.ReadToEndAsync()
+                $lines = New-Object System.Collections.Generic.List[string]
+                while (-not $process.StandardOutput.EndOfStream) {
+                    $line = $process.StandardOutput.ReadLine()
+                    if ($null -eq $line) {
+                        continue
+                    }
+                    $lines.Add([string]$line)
+                    if (-not [string]::IsNullOrWhiteSpace($progressLogPath)) {
+                        Add-Content -LiteralPath $progressLogPath -Value ([string]$line) -Encoding UTF8
+                    }
+                }
+
+                $process.WaitForExit()
+                $standardError = [string]$standardErrorTask.GetAwaiter().GetResult()
+                $errorLines = @(
+                    $standardError -split "`r?`n" |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+                )
+                $processId = [int]$process.Id
+                $exitCode = [int]$process.ExitCode
+
+                [PSCustomObject]@{
+                    commandId = [string]$ScheduledCommand.id
+                    processId = $processId
+                    exitCode  = $exitCode
+                    output    = @($lines.ToArray())
+                    error     = @($errorLines)
+                }
+            }
+            finally {
+                $process.Dispose()
+            }
+        }
+}


### PR DESCRIPTION
## Ticket

RS-1508

## Summary

Fixes a backup worker crash that can occur when RenderKit is hosted in an embedded PowerShell runspace.

The parallel backup process runner previously attached a PowerShell script block to `Process.ErrorDataReceived`. The .NET event can execute on a thread-pool thread without an available `DefaultRunspace`, which may raise an unhandled `PSInvalidOperationException` and terminate the host process.

## Changes

- replace the `ErrorDataReceived` PowerShell event callback with asynchronous `StandardError.ReadToEndAsync()` consumption
- keep stdout streaming intact for FFmpeg progress handling
- preserve PID tracking, exit codes, stderr output and failure simulation behavior
- dispose the spawned process reliably
- add regression coverage for the embedded-runspace-safe execution path

## Notes

The implementation is internal and does not change the public RenderKit command surface.