### PR TITLE
RS-1513: Harden worker diagnostic logging

### DIFF
--- a/Tests/Job/RenderKit.WorkerDiagnosticsHardening.Tests.ps1
+++ b/Tests/Job/RenderKit.WorkerDiagnosticsHardening.Tests.ps1
@@ -53,12 +53,30 @@ Describe 'RenderKit worker diagnostic hardening' {
         }
     }
 
+    It 'does not fail when default log-path resolution itself fails' {
+        InModuleScope RenderKit {
+            Mock Get-RenderKitWorkerLogPath {
+                throw 'worker log root is unavailable'
+            }
+
+            {
+                Write-RenderKitWorkerLogEntry `
+                    -WorkerId 'resolver-failure-worker' `
+                    -Message 'diagnostic message' |
+                    Out-Null
+            } | Should -Not -Throw
+
+            Assert-MockCalled Get-RenderKitWorkerLogPath -Times 1 -Exactly
+        }
+    }
+
     It 'documents why worker logging is best-effort' {
         $definition = InModuleScope RenderKit {
             (Get-Command Write-RenderKitWorkerLogEntry).Definition
         }
 
-        $definition | Should -Match 'persisted worker/job state remains the durable source of truth'
+        $definition | Should -Match 'RS-1513'
+        $definition | Should -Match 'Path resolution belongs inside the same protected'
         $definition | Should -Match 'ErrorAction Stop'
         $definition | Should -Match 'WarningAction Continue'
     }

--- a/src/Private/Job/RenderKit.WorkerDiagnosticsHardening.ps1
+++ b/src/Private/Job/RenderKit.WorkerDiagnosticsHardening.ps1
@@ -11,14 +11,15 @@ function Write-RenderKitWorkerLogEntry {
         [string]$LogPath
     )
 
-    # Worker diagnostics are best-effort and must never become worker control
-    # flow. The persisted worker/job state remains the durable source of truth
-    # if a log path disappears, becomes read-only, or is temporarily unavailable.
-    if ([string]::IsNullOrWhiteSpace($LogPath)) {
-        $LogPath = Get-RenderKitWorkerLogPath -WorkerId $WorkerId
-    }
-
+    # RS-1513: Worker diagnostics are strictly best-effort and must never become
+    # worker control flow. Path resolution belongs inside the same protected
+    # boundary as directory creation and file writes; otherwise a failing default
+    # log-path resolver can still terminate an otherwise healthy worker tick.
     try {
+        if ([string]::IsNullOrWhiteSpace($LogPath)) {
+            $LogPath = Get-RenderKitWorkerLogPath -WorkerId $WorkerId
+        }
+
         $logRoot = Split-Path -Path $LogPath -Parent
         if (-not [string]::IsNullOrWhiteSpace($logRoot) -and
             -not (Test-Path -LiteralPath $logRoot -PathType Container)) {
@@ -46,11 +47,17 @@ function Write-RenderKitWorkerLogEntry {
         return $LogPath
     }
     catch {
-        # Explicit Continue prevents a caller-level WarningPreference=Stop from
+        # Explicit Continue prevents caller-level WarningPreference=Stop from
         # turning this diagnostic fallback back into a worker failure.
+        $displayPath = if ([string]::IsNullOrWhiteSpace($LogPath)) {
+            '<default worker log>'
+        }
+        else {
+            $LogPath
+        }
         Write-Warning `
             -Message ("RenderKit could not write worker log '{0}': {1}" -f
-                $LogPath,
+                $displayPath,
                 $_.Exception.Message) `
             -WarningAction Continue
         return $null


### PR DESCRIPTION
## Summary

Make worker diagnostic logging strictly best-effort, including failures that occur while resolving the default worker log path.

## Changes

- move default worker log-path resolution inside the protected diagnostic boundary
- keep directory creation and file writes isolated from worker control flow
- keep fallback warnings non-terminating even with caller-level `WarningPreference = Stop`
- use a safe display placeholder when path resolution fails before a concrete log path exists
- document the control-flow boundary directly in the implementation with `RS-1513`
- add regression coverage for default-path resolver failures

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.