### PR TITLE
RS-1514: Harden cross-platform backup locks

### DIFF
--- a/Tests/Backup/RenderKit.BackupLockCrossPlatform.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupLockCrossPlatform.Tests.ps1
@@ -116,6 +116,51 @@ Describe 'RenderKit backup lock cross-platform ownership' {
         $result.IsStale | Should -BeTrue
     }
 
+    It 'falls back to lock age when a local lock has no usable process id' {
+        $projectRoot = Join-Path $TestDrive 'local-unverifiable-lock-project'
+        New-Item `
+            -ItemType Directory `
+            -Path (Join-Path $projectRoot '.renderkit') `
+            -Force |
+            Out-Null
+
+        $result = InModuleScope RenderKit -Parameters @{
+            ProjectRoot = $projectRoot
+        } {
+            $lockPath = Get-BackupLockPath -ProjectRoot $ProjectRoot
+            [PSCustomObject]@{
+                lockType  = 'backup'
+                lockedAt  = (Get-Date).ToUniversalTime().ToString('o')
+                processId = 'not-a-pid'
+                machine   = [System.Environment]::MachineName
+            } |
+                ConvertTo-Json |
+                Set-Content -LiteralPath $lockPath -Encoding UTF8
+
+            $fresh = Test-BackupLock `
+                -ProjectRoot $ProjectRoot `
+                -StaleThreshold (New-TimeSpan -Hours 24)
+
+            (Get-Item -LiteralPath $lockPath).LastWriteTime = (Get-Date).AddHours(-48)
+            $aged = Test-BackupLock `
+                -ProjectRoot $ProjectRoot `
+                -StaleThreshold (New-TimeSpan -Hours 24)
+
+            [PSCustomObject]@{
+                fresh = $fresh
+                aged = $aged
+                definition = (Get-Command Test-BackupLock).Definition
+            }
+        }
+
+        $result.fresh.IsLocked | Should -BeTrue
+        $result.fresh.IsStale | Should -BeFalse
+        $result.aged.IsLocked | Should -BeFalse
+        $result.aged.IsStale | Should -BeTrue
+        $result.definition | Should -Match 'RS-1514'
+        $result.definition | Should -Match 'TryParse'
+    }
+
     It 'takes over the same observed stale lock without a remove-create window' {
         $projectRoot = Join-Path $TestDrive 'stale-takeover-project'
         New-Item `

--- a/src/Private/Backup/Test-BackupLock.ps1
+++ b/src/Private/Backup/Test-BackupLock.ps1
@@ -41,10 +41,10 @@ function Test-BackupLock {
         $lockMachine = [string]$lock.maschine
     }
 
-    # PID checks are meaningful only for a lock that positively identifies the
-    # current machine. Legacy/foreign locks without machine identity are treated
-    # as remote and may become stale only by age; guessing "local" can delete an
-    # active lock on a shared project path when another host happens to use it.
+    # RS-1514: PID checks are meaningful only when the lock positively identifies
+    # the current machine and contains a usable positive PID. A missing/invalid
+    # PID is not proof that a lock is alive; fall back to age-based ownership
+    # uncertainty instead of keeping such a lock permanently active.
     $currentMachine = [System.Environment]::MachineName
     $isLocalMachine = -not [string]::IsNullOrWhiteSpace($lockMachine) -and
         $lockMachine.Equals(
@@ -52,32 +52,58 @@ function Test-BackupLock {
             [System.StringComparison]::OrdinalIgnoreCase
         )
 
+    $lockProcessId = 0
+    $hasUsableProcessId = $false
+    if ($null -ne $lock.processId) {
+        $parsedProcessId = 0
+        if ([int]::TryParse([string]$lock.processId, [ref]$parsedProcessId) -and
+            $parsedProcessId -gt 0) {
+            $lockProcessId = $parsedProcessId
+            $hasUsableProcessId = $true
+        }
+    }
+
     $isStale = $false
 
-    if ($isLocalMachine) {
-        if ($lock.processId -and -not (Get-Process -Id $lock.processId -ErrorAction SilentlyContinue)) {
+    if ($isLocalMachine -and $hasUsableProcessId) {
+        if (-not (Get-Process -Id $lockProcessId -ErrorAction SilentlyContinue)) {
             $isStale = $true
         }
     }
     else {
-        $lockAge = (Get-Date) - (Get-Item -LiteralPath $lockPath -ErrorAction Stop).LastWriteTime
+        $lockAge = (Get-Date) - (
+            Get-Item -LiteralPath $lockPath -ErrorAction Stop
+        ).LastWriteTime
         $displayMachine = if ([string]::IsNullOrWhiteSpace($lockMachine)) {
             'unknown-machine'
         }
         else {
             $lockMachine
         }
+        $ownershipReason = if ($isLocalMachine) {
+            "local lock has no usable process id"
+        }
+        else {
+            "lock process cannot be verified on this machine"
+        }
 
         if ($lockAge -gt $StaleThreshold) {
             $isStale = $true
             Write-RenderKitLog `
                 -Level Warning `
-                -Message "Lock originates from machine '$displayMachine' and is $([int]$lockAge.TotalHours)h old. Treating as stale."
+                -Message ("Lock from '{0}' is {1}h old and {2}. Treating as stale." -f
+                    $displayMachine,
+                    [int]$lockAge.TotalHours,
+                    $ownershipReason)
         }
         else {
             Write-RenderKitLog `
                 -Level Warning `
-                -Message "Lock originates from machine '$displayMachine'. Cannot verify remote process. Lock age: $([int]$lockAge.TotalHours)h (threshold: $([int]$StaleThreshold.TotalHours)h)."
+                -Message ("Lock from '{0}' is {1}h old and {2}. Keeping it active until the {3}h stale threshold." -f
+                    $displayMachine,
+                    [int]$lockAge.TotalHours,
+                    $ownershipReason,
+                    [int]$StaleThreshold.TotalHours)
         }
     }
 


### PR DESCRIPTION
## Summary

Harden backup-lock ownership checks and stale detection across supported platforms and shared project paths.

## Changes

- keep machine ownership based on portable runtime identity
- validate persisted local process ids before attempting a PID liveness check
- fall back to the configured stale-age threshold when a local lock has no usable PID
- preserve conservative handling for foreign and legacy locks on shared storage
- keep race-safe stale takeover through the same exclusive file handle
- document the unverifiable-ownership rule directly in the implementation with `RS-1514`
- add regression coverage for invalid/missing local process ownership

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.