### PR TITLE
RS-1515: Guard worker PID recovery by host identity

### DIFF
--- a/Tests/Job/RenderKit.WorkerRecoveryHostGuard.Tests.ps1
+++ b/Tests/Job/RenderKit.WorkerRecoveryHostGuard.Tests.ps1
@@ -1,0 +1,112 @@
+Describe 'RS-1515 worker recovery host guard' {
+    BeforeAll {
+        $repositoryRoot = Split-Path -Parent (
+            Split-Path -Parent $PSScriptRoot)
+        Import-Module `
+            (Join-Path $repositoryRoot 'RenderKit.psd1') `
+            -Force
+    }
+
+    AfterAll {
+        Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'does not classify foreign worker state as a local crash' {
+        $result = InModuleScope RenderKit {
+            $previous = [PSCustomObject]@{
+                status = 'Running'
+                machine = 'definitely-not-this-machine'
+                processId = $PID
+            }
+            Mock Read-RenderKitWorkerState { $previous }
+            Mock Test-RenderKitWorkerProcessAlive {
+                throw 'foreign state must not reach local PID probing'
+            }
+
+            $outcome = Register-RenderKitWorkerCrashIfNeeded `
+                -WorkerId 'foreign-worker'
+            [PSCustomObject]@{
+                outcome = $outcome
+                pidProbeCalls = (Get-MockCalledCount `
+                    -CommandName Test-RenderKitWorkerProcessAlive)
+            }
+        }
+
+        $result.outcome.crashDetected | Should -BeFalse
+        $result.pidProbeCalls | Should -Be 0
+    }
+
+    It 'does not classify legacy state without machine identity as a local crash' {
+        $result = InModuleScope RenderKit {
+            $previous = [PSCustomObject]@{
+                status = 'Idle'
+                machine = $null
+                processId = 2147483647
+            }
+            Mock Read-RenderKitWorkerState { $previous }
+            Mock Test-RenderKitWorkerProcessAlive {
+                throw 'unowned legacy state must not reach local PID probing'
+            }
+
+            $outcome = Register-RenderKitWorkerCrashIfNeeded `
+                -WorkerId 'legacy-worker'
+            [PSCustomObject]@{
+                outcome = $outcome
+                pidProbeCalls = (Get-MockCalledCount `
+                    -CommandName Test-RenderKitWorkerProcessAlive)
+            }
+        }
+
+        $result.outcome.crashDetected | Should -BeFalse
+        $result.pidProbeCalls | Should -Be 0
+    }
+
+    It 'treats an invalid PID as dead only after local host ownership is confirmed' {
+        $result = InModuleScope RenderKit {
+            $previous = [PSCustomObject]@{
+                status = 'Running'
+                machine = [System.Environment]::MachineName
+                processId = 'invalid-pid'
+                processedCount = 2
+                idleTickCount = 1
+                recoveredJobIds = @()
+                startedAtUtc = (Get-Date).ToUniversalTime().AddMinutes(-5).ToString('o')
+            }
+            Mock Read-RenderKitWorkerState { $previous }
+            Mock Test-RenderKitWorkerProcessAlive { $true }
+            Mock New-RenderKitWorkerState {
+                [PSCustomObject]@{
+                    status = 'CrashDetected'
+                    stoppedAtUtc = $null
+                }
+            }
+            Mock Save-RenderKitWorkerState { 'ignored-state-path' }
+            Mock Write-RenderKitWorkerLogEntry { $null }
+
+            $outcome = Register-RenderKitWorkerCrashIfNeeded `
+                -WorkerId 'local-invalid-pid-worker' `
+                -LogPath 'worker.log'
+            [PSCustomObject]@{
+                outcome = $outcome
+                pidProbeCalls = (Get-MockCalledCount `
+                    -CommandName Test-RenderKitWorkerProcessAlive)
+                saveCalls = (Get-MockCalledCount `
+                    -CommandName Save-RenderKitWorkerState)
+            }
+        }
+
+        $result.outcome.crashDetected | Should -BeTrue
+        $result.pidProbeCalls | Should -Be 0
+        $result.saveCalls | Should -Be 1
+    }
+
+    It 'documents the host ownership boundary in crash recovery' {
+        $definition = InModuleScope RenderKit {
+            (Get-Command Register-RenderKitWorkerCrashIfNeeded).Definition
+        }
+
+        $definition | Should -Match 'RS-1515'
+        $definition | Should -Match 'PID is scoped to the host'
+        $definition | Should -Match 'isLocalState'
+    }
+}

--- a/Tests/Job/RenderKit.WorkerRecoveryHostGuard.Tests.ps1
+++ b/Tests/Job/RenderKit.WorkerRecoveryHostGuard.Tests.ps1
@@ -25,15 +25,14 @@ Describe 'RS-1515 worker recovery host guard' {
 
             $outcome = Register-RenderKitWorkerCrashIfNeeded `
                 -WorkerId 'foreign-worker'
-            [PSCustomObject]@{
-                outcome = $outcome
-                pidProbeCalls = (Get-MockCalledCount `
-                    -CommandName Test-RenderKitWorkerProcessAlive)
-            }
+            Assert-MockCalled `
+                -CommandName Test-RenderKitWorkerProcessAlive `
+                -Times 0 `
+                -Exactly
+            $outcome
         }
 
-        $result.outcome.crashDetected | Should -BeFalse
-        $result.pidProbeCalls | Should -Be 0
+        $result.crashDetected | Should -BeFalse
     }
 
     It 'does not classify legacy state without machine identity as a local crash' {
@@ -50,15 +49,14 @@ Describe 'RS-1515 worker recovery host guard' {
 
             $outcome = Register-RenderKitWorkerCrashIfNeeded `
                 -WorkerId 'legacy-worker'
-            [PSCustomObject]@{
-                outcome = $outcome
-                pidProbeCalls = (Get-MockCalledCount `
-                    -CommandName Test-RenderKitWorkerProcessAlive)
-            }
+            Assert-MockCalled `
+                -CommandName Test-RenderKitWorkerProcessAlive `
+                -Times 0 `
+                -Exactly
+            $outcome
         }
 
-        $result.outcome.crashDetected | Should -BeFalse
-        $result.pidProbeCalls | Should -Be 0
+        $result.crashDetected | Should -BeFalse
     }
 
     It 'treats an invalid PID as dead only after local host ownership is confirmed' {
@@ -86,18 +84,18 @@ Describe 'RS-1515 worker recovery host guard' {
             $outcome = Register-RenderKitWorkerCrashIfNeeded `
                 -WorkerId 'local-invalid-pid-worker' `
                 -LogPath 'worker.log'
-            [PSCustomObject]@{
-                outcome = $outcome
-                pidProbeCalls = (Get-MockCalledCount `
-                    -CommandName Test-RenderKitWorkerProcessAlive)
-                saveCalls = (Get-MockCalledCount `
-                    -CommandName Save-RenderKitWorkerState)
-            }
+            Assert-MockCalled `
+                -CommandName Test-RenderKitWorkerProcessAlive `
+                -Times 0 `
+                -Exactly
+            Assert-MockCalled `
+                -CommandName Save-RenderKitWorkerState `
+                -Times 1 `
+                -Exactly
+            $outcome
         }
 
-        $result.outcome.crashDetected | Should -BeTrue
-        $result.pidProbeCalls | Should -Be 0
-        $result.saveCalls | Should -Be 1
+        $result.crashDetected | Should -BeTrue
     }
 
     It 'documents the host ownership boundary in crash recovery' {

--- a/src/Private/Job/RenderKit.WorkerRecoveryHostGuard.ps1
+++ b/src/Private/Job/RenderKit.WorkerRecoveryHostGuard.ps1
@@ -1,0 +1,97 @@
+function Register-RenderKitWorkerCrashIfNeeded {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkerId,
+        [string]$JobType,
+        [string]$QueueName,
+        [string]$LogPath
+    )
+
+    $previous = Read-RenderKitWorkerState -WorkerId $WorkerId
+    if (-not $previous -or [string]$previous.status -notin @('Starting', 'Running', 'Idle')) {
+        return [PSCustomObject]@{
+            crashDetected = $false
+            previousState = $previous
+        }
+    }
+
+    # RS-1515: A PID is scoped to the host that created the worker state. Shared
+    # state can contain active workers from another machine, so "not locally
+    # alive" must not be interpreted as "crashed" until ownership is explicitly
+    # confirmed. Missing machine identity is also unverifiable and is therefore
+    # left untouched for compatibility with legacy state files.
+    $previousMachine = if ($previous.PSObject.Properties.Name -contains 'machine') {
+        [string]$previous.machine
+    }
+    else {
+        $null
+    }
+    $currentMachine = [System.Environment]::MachineName
+    $isLocalState = -not [string]::IsNullOrWhiteSpace($previousMachine) -and
+        $previousMachine.Equals(
+            $currentMachine,
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
+
+    if (-not $isLocalState) {
+        return [PSCustomObject]@{
+            crashDetected = $false
+            previousState = $previous
+        }
+    }
+
+    $previousProcessId = 0
+    $hasUsableProcessId = [int]::TryParse(
+        [string]$previous.processId,
+        [ref]$previousProcessId
+    ) -and $previousProcessId -gt 0
+
+    $alive = if ($hasUsableProcessId) {
+        Test-RenderKitWorkerProcessAlive `
+            -ProcessId $previousProcessId `
+            -MachineName $previousMachine
+    }
+    else {
+        $false
+    }
+
+    if ($alive) {
+        return [PSCustomObject]@{
+            crashDetected = $false
+            previousState = $previous
+        }
+    }
+
+    $state = New-RenderKitWorkerState `
+        -WorkerId $WorkerId `
+        -JobType $JobType `
+        -QueueName $QueueName `
+        -LogPath $LogPath `
+        -Status CrashDetected `
+        -ProcessedCount ([int]$previous.processedCount) `
+        -IdleTickCount ([int]$previous.idleTickCount) `
+        -RecoveredJobIds @($previous.recoveredJobIds) `
+        -Capabilities $(if (
+            $previous.PSObject.Properties.Name -contains 'capabilities'
+        ) { $previous.capabilities } else { $null }) `
+        -LastError ([PSCustomObject]@{
+            message       = 'Previous worker process is no longer alive.'
+            previousPid   = $previous.processId
+            detectedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+        }) `
+        -StartedAtUtc ([string]$previous.startedAtUtc)
+    $state.stoppedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+    Save-RenderKitWorkerState -State $state | Out-Null
+    Write-RenderKitWorkerLogEntry `
+        -WorkerId $WorkerId `
+        -LogPath $LogPath `
+        -Level Warning `
+        -Message ("Detected crashed worker process '{0}'." -f $previous.processId) |
+        Out-Null
+
+    return [PSCustomObject]@{
+        crashDetected = $true
+        previousState = $previous
+    }
+}


### PR DESCRIPTION
## Summary

Prevent worker crash recovery from interpreting foreign or legacy shared worker state as a local dead process.

## Changes

- require persisted worker state to explicitly identify the current machine before local PID recovery is attempted
- leave foreign and machine-less legacy worker state untouched instead of marking it `CrashDetected`
- parse persisted PIDs defensively before process probing
- treat an invalid PID as dead only after local host ownership has been established
- keep portable `Environment.MachineName` worker-state identity
- document the host/PID ownership boundary directly in the recovery implementation with `RS-1515`
- add regression coverage for foreign, legacy, and invalid-PID worker state

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.