### PR TITLE
RS-1516: Normalize portable backup audit identity

### DIFF
--- a/Tests/Backup/RenderKit.BackupRuntimeIdentity.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupRuntimeIdentity.Tests.ps1
@@ -63,4 +63,52 @@ Describe 'RenderKit backup runtime identity' {
         $job.requestedBy.user | Should -Be ([System.Environment]::UserName)
         $job.requestedBy.machine | Should -Be ([System.Environment]::MachineName)
     }
+
+    It 'preserves explicit and custom audit fields from hashtable callers' {
+        $job = InModuleScope RenderKit {
+            New-BackupProjectJob `
+                -Payload ([PSCustomObject]@{
+                    schemaVersion = '1.0'
+                }) `
+                -RequestedBy @{
+                    user = 'explicit-user'
+                    machine = ''
+                    actorId = 'actor-42'
+                }
+        }
+
+        $job.requestedBy.user | Should -Be 'explicit-user'
+        $job.requestedBy.machine | Should -Be ([System.Environment]::MachineName)
+        $job.requestedBy.actorId | Should -Be 'actor-42'
+    }
+
+    It 'does not mutate the caller audit object while filling portable defaults' {
+        $result = InModuleScope RenderKit {
+            $requestedBy = [PSCustomObject]@{
+                user = $null
+                actorId = 'shared-context'
+            }
+            $job = New-BackupProjectJob `
+                -Payload ([PSCustomObject]@{
+                    schemaVersion = '1.0'
+                }) `
+                -RequestedBy $requestedBy
+
+            [PSCustomObject]@{
+                job = $job
+                original = $requestedBy
+                definition = (
+                    Get-Command ConvertTo-BackupRequestedByRuntimeIdentity
+                ).Definition
+            }
+        }
+
+        $result.job.requestedBy.user | Should -Be ([System.Environment]::UserName)
+        $result.job.requestedBy.machine | Should -Be ([System.Environment]::MachineName)
+        $result.job.requestedBy.actorId | Should -Be 'shared-context'
+        $result.original.user | Should -BeNullOrEmpty
+        $result.original.PSObject.Properties.Name | Should -Not -Contain 'machine'
+        $result.definition | Should -Match 'RS-1516'
+        $result.definition | Should -Match 'new object instead of decorating'
+    }
 }

--- a/src/Private/Backup/New-BackupProjectJobRuntimeIdentity.ps1
+++ b/src/Private/Backup/New-BackupProjectJobRuntimeIdentity.ps1
@@ -1,3 +1,39 @@
+function ConvertTo-BackupRequestedByRuntimeIdentity {
+    [CmdletBinding()]
+    param(
+        [object]$RequestedBy
+    )
+
+    # RS-1516: Normalize into a new object instead of decorating the caller's
+    # instance in-place. Audit context is often reused by hosts across multiple
+    # operations, so adding fallback properties to the supplied object would be
+    # an observable side effect unrelated to creating this backup job.
+    $normalized = [ordered]@{}
+    if ($RequestedBy -is [System.Collections.IDictionary]) {
+        foreach ($key in @($RequestedBy.Keys)) {
+            $normalized[[string]$key] = $RequestedBy[$key]
+        }
+    }
+    elseif ($RequestedBy) {
+        foreach ($property in @($RequestedBy.PSObject.Properties)) {
+            if ($property.MemberType -in @('NoteProperty', 'Property', 'AliasProperty')) {
+                $normalized[[string]$property.Name] = $property.Value
+            }
+        }
+    }
+
+    if (-not $normalized.Contains('user') -or
+        [string]::IsNullOrWhiteSpace([string]$normalized['user'])) {
+        $normalized['user'] = [System.Environment]::UserName
+    }
+    if (-not $normalized.Contains('machine') -or
+        [string]::IsNullOrWhiteSpace([string]$normalized['machine'])) {
+        $normalized['machine'] = [System.Environment]::MachineName
+    }
+
+    return [PSCustomObject]$normalized
+}
+
 function New-BackupProjectJob {
     [CmdletBinding()]
     param(
@@ -17,25 +53,8 @@ function New-BackupProjectJob {
     # are empty on Unix. Normalize the persisted audit identity at the private
     # job boundary so every caller gets portable user/machine metadata without
     # changing the public backup command contract.
-    if (-not $RequestedBy) {
-        $RequestedBy = [PSCustomObject]@{}
-    }
-    if ($RequestedBy.PSObject.Properties.Name -notcontains 'user' -or
-        [string]::IsNullOrWhiteSpace([string]$RequestedBy.user)) {
-        $RequestedBy |
-            Add-Member `
-                -NotePropertyName user `
-                -NotePropertyValue ([System.Environment]::UserName) `
-                -Force
-    }
-    if ($RequestedBy.PSObject.Properties.Name -notcontains 'machine' -or
-        [string]::IsNullOrWhiteSpace([string]$RequestedBy.machine)) {
-        $RequestedBy |
-            Add-Member `
-                -NotePropertyName machine `
-                -NotePropertyValue ([System.Environment]::MachineName) `
-                -Force
-    }
+    $RequestedBy = ConvertTo-BackupRequestedByRuntimeIdentity `
+        -RequestedBy $RequestedBy
 
     $job = New-RenderKitJob `
         -JobType 'BackupProject' `


### PR DESCRIPTION
## Summary

Normalize backup manifest and background-job audit identity without mutating caller-owned context objects.

## Changes

- keep backup manifest identity on portable `Environment.UserName` / `Environment.MachineName`
- normalize `RequestedBy` into a new audit object at the private backup-job boundary
- preserve explicit user/machine values and arbitrary additional audit fields
- support both dictionary/hashtable and object-shaped caller context
- fill only missing or blank portable identity fields
- avoid observable mutation of caller-owned audit context
- document the normalization boundary directly in the implementation with `RS-1516`
- add regression coverage for hashtable callers and non-mutating normalization

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.