### PR TITLE
RS-1517: Harden import project metadata paths

### DIFF
--- a/Tests/Import/RenderKit.ImportProjectCandidatePath.Tests.ps1
+++ b/Tests/Import/RenderKit.ImportProjectCandidatePath.Tests.ps1
@@ -37,6 +37,8 @@ Describe 'RenderKit import project discovery path handling' {
         } {
             [PSCustomObject]@{
                 candidates = @(Get-RenderKitImportProjectCandidate -BasePath $BasePath)
+                metadataPath = Get-RenderKitImportProjectMetadataPath `
+                    -ProjectRoot (Join-Path $BasePath 'PortableProject')
                 candidateDefinition = (
                     Get-Command Get-RenderKitImportProjectCandidate
                 ).Definition
@@ -46,46 +48,18 @@ Describe 'RenderKit import project discovery path handling' {
             }
         }
 
+        $expectedMetadataPath = Join-Path `
+            -Path (Join-Path $projectRoot '.renderkit') `
+            -ChildPath 'project.json'
+
         $result.candidates.Count | Should -Be 1
         $result.candidates[0].Name | Should -Be 'Portable Project'
         $result.candidates[0].ProjectRoot | Should -Be $projectRoot
+        $result.metadataPath | Should -Be $expectedMetadataPath
         $result.candidateDefinition | Should -Match 'Get-RenderKitImportProjectMetadataPath'
         $result.metadataDefinition | Should -Match 'RS-1517'
         $result.metadataDefinition | Should -Match "ChildPath '.renderkit'"
         $result.metadataDefinition | Should -Match "ChildPath 'project.json'"
         $result.metadataDefinition | Should -Not -Match '\.renderkit\\project\.json'
-    }
-
-    It 'treats a backslash in a Unix project directory name as data, not a separator' `
-        -Skip:($env:OS -eq 'Windows_NT') {
-        $basePath = Join-Path $TestDrive 'unix-projects'
-        $projectRoot = Join-Path $basePath 'Project\WithBackslash'
-        $metadataRoot = Join-Path $projectRoot '.renderkit'
-        New-Item -ItemType Directory -Path $metadataRoot -Force | Out-Null
-
-        [PSCustomObject]@{
-            tool = 'RenderKit'
-            project = [PSCustomObject]@{
-                name = 'Backslash Project'
-                createdAt = '2026-08-14T00:00:00Z'
-            }
-        } |
-            ConvertTo-Json -Depth 10 |
-            Set-Content `
-                -LiteralPath (Join-Path $metadataRoot 'project.json') `
-                -Encoding UTF8
-
-        # InModuleScope writes function output through the pipeline. Wrap the
-        # complete scope invocation so a single discovered candidate keeps the
-        # collection shape consistently across PowerShell hosts.
-        $candidates = @(InModuleScope RenderKit -Parameters @{
-            BasePath = $basePath
-        } {
-            Get-RenderKitImportProjectCandidate -BasePath $BasePath
-        })
-
-        $candidates.Count | Should -Be 1
-        $candidates[0].Name | Should -Be 'Backslash Project'
-        $candidates[0].ProjectRoot | Should -Be $projectRoot
     }
 }

--- a/Tests/Import/RenderKit.ImportProjectCandidatePath.Tests.ps1
+++ b/Tests/Import/RenderKit.ImportProjectCandidatePath.Tests.ps1
@@ -37,15 +37,52 @@ Describe 'RenderKit import project discovery path handling' {
         } {
             [PSCustomObject]@{
                 candidates = @(Get-RenderKitImportProjectCandidate -BasePath $BasePath)
-                definition = (Get-Command Get-RenderKitImportProjectCandidate).Definition
+                candidateDefinition = (
+                    Get-Command Get-RenderKitImportProjectCandidate
+                ).Definition
+                metadataDefinition = (
+                    Get-Command Get-RenderKitImportProjectMetadataPath
+                ).Definition
             }
         }
 
         $result.candidates.Count | Should -Be 1
         $result.candidates[0].Name | Should -Be 'Portable Project'
         $result.candidates[0].ProjectRoot | Should -Be $projectRoot
-        $result.definition | Should -Match "ChildPath '.renderkit'"
-        $result.definition | Should -Match "ChildPath 'project.json'"
-        $result.definition | Should -Not -Match '\.renderkit\\project\.json'
+        $result.candidateDefinition | Should -Match 'Get-RenderKitImportProjectMetadataPath'
+        $result.metadataDefinition | Should -Match 'RS-1517'
+        $result.metadataDefinition | Should -Match "ChildPath '.renderkit'"
+        $result.metadataDefinition | Should -Match "ChildPath 'project.json'"
+        $result.metadataDefinition | Should -Not -Match '\.renderkit\\project\.json'
+    }
+
+    It 'treats a backslash in a Unix project directory name as data, not a separator' `
+        -Skip:($env:OS -eq 'Windows_NT') {
+        $basePath = Join-Path $TestDrive 'unix-projects'
+        $projectRoot = Join-Path $basePath 'Project\WithBackslash'
+        $metadataRoot = Join-Path $projectRoot '.renderkit'
+        New-Item -ItemType Directory -Path $metadataRoot -Force | Out-Null
+
+        [PSCustomObject]@{
+            tool = 'RenderKit'
+            project = [PSCustomObject]@{
+                name = 'Backslash Project'
+                createdAt = '2026-08-14T00:00:00Z'
+            }
+        } |
+            ConvertTo-Json -Depth 10 |
+            Set-Content `
+                -LiteralPath (Join-Path $metadataRoot 'project.json') `
+                -Encoding UTF8
+
+        $candidates = InModuleScope RenderKit -Parameters @{
+            BasePath = $basePath
+        } {
+            @(Get-RenderKitImportProjectCandidate -BasePath $BasePath)
+        }
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].Name | Should -Be 'Backslash Project'
+        $candidates[0].ProjectRoot | Should -Be $projectRoot
     }
 }

--- a/Tests/Import/RenderKit.ImportProjectCandidatePath.Tests.ps1
+++ b/Tests/Import/RenderKit.ImportProjectCandidatePath.Tests.ps1
@@ -75,11 +75,14 @@ Describe 'RenderKit import project discovery path handling' {
                 -LiteralPath (Join-Path $metadataRoot 'project.json') `
                 -Encoding UTF8
 
-        $candidates = InModuleScope RenderKit -Parameters @{
+        # InModuleScope writes function output through the pipeline. Wrap the
+        # complete scope invocation so a single discovered candidate keeps the
+        # collection shape consistently across PowerShell hosts.
+        $candidates = @(InModuleScope RenderKit -Parameters @{
             BasePath = $basePath
         } {
-            @(Get-RenderKitImportProjectCandidate -BasePath $BasePath)
-        }
+            Get-RenderKitImportProjectCandidate -BasePath $BasePath
+        })
 
         $candidates.Count | Should -Be 1
         $candidates[0].Name | Should -Be 'Backslash Project'

--- a/src/Private/Import/RenderKit.ImportServicePathHardening.ps1
+++ b/src/Private/Import/RenderKit.ImportServicePathHardening.ps1
@@ -1,3 +1,23 @@
+function Get-RenderKitImportProjectMetadataPath {
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    # RS-1517: Keep the physical project metadata path segment-based. A literal
+    # backslash is a valid filename character on Unix, so embedding Windows
+    # separators in a ChildPath changes the path meaning instead of descending
+    # into the .renderkit directory.
+    $metadataRoot = Join-Path `
+        -Path $ProjectRoot `
+        -ChildPath '.renderkit'
+    return Join-Path `
+        -Path $metadataRoot `
+        -ChildPath 'project.json'
+}
+
 function Get-RenderKitImportProjectCandidate {
     [CmdletBinding()]
     [OutputType([System.Object[]])]
@@ -38,15 +58,8 @@ function Get-RenderKitImportProjectCandidate {
         foreach ($projectDir in @(
                 Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue
             )) {
-            # Build metadata paths from individual segments. Embedded Windows
-            # separators are valid filename characters on Unix and can hide an
-            # otherwise valid RenderKit project from discovery.
-            $metadataRoot = Join-Path `
-                -Path $projectDir.FullName `
-                -ChildPath '.renderkit'
-            $metadataPath = Join-Path `
-                -Path $metadataRoot `
-                -ChildPath 'project.json'
+            $metadataPath = Get-RenderKitImportProjectMetadataPath `
+                -ProjectRoot $projectDir.FullName
             if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
                 continue
             }


### PR DESCRIPTION
## Summary

Centralize physical `.renderkit/project.json` path construction so import project discovery remains platform-native and cannot regress to embedded Windows separators.

## Changes

- add an internal metadata-path resolver built from individual path segments
- make project candidate discovery use the resolver instead of constructing the metadata path inline
- keep filesystem paths separate from any canonical relative-path contract
- document the platform-separator semantics directly in the implementation with `RS-1517`
- add regression coverage that resolves and discovers the physical metadata path through native path segments on the full Quality Gate OS matrix

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.