### PR TITLE
RS-1518: Keep terminating backup errors canonical

### DIFF
--- a/Tests/Backup/RenderKit.BackupErrorRecordHardening.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupErrorRecordHardening.Tests.ps1
@@ -1,0 +1,63 @@
+Describe 'RS-1518 backup error record hardening' {
+    BeforeAll {
+        $repositoryRoot = Split-Path -Parent (
+            Split-Path -Parent $PSScriptRoot)
+        Import-Module `
+            (Join-Path $repositoryRoot 'RenderKit.psd1') `
+            -Force
+    }
+
+    AfterAll {
+        Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'keeps terminating validation failures off the secondary error stream' {
+        $definitions = InModuleScope RenderKit {
+            [PSCustomObject]@{
+                manifest = (Get-Command Save-BackupManifest).Definition
+                archivePath = (Get-Command Resolve-BackupArchivePath).Definition
+                logInjection = (Get-Command Add-BackupLogsToArchive).Definition
+                fileInjection = (Get-Command Add-BackupFileToArchive).Definition
+                integrity = (Get-Command Test-BackupArchiveContentIntegrity).Definition
+            }
+        }
+
+        foreach ($definition in @(
+                $definitions.manifest,
+                $definitions.archivePath,
+                $definitions.logInjection,
+                $definitions.fileInjection,
+                $definitions.integrity
+            )) {
+            $definition | Should -Match 'RS-1518'
+            $definition | Should -Match 'NoConsole'
+        }
+    }
+
+    It 'still throws the canonical manifest validation error' {
+        InModuleScope RenderKit {
+            {
+                Save-BackupManifest `
+                    -Manifest ([PSCustomObject]@{}) `
+                    -ErrorAction Stop
+            } | Should -Throw '*Either -ProjectRoot or -ManifestPath*'
+        }
+    }
+
+    It 'still throws canonical archive injection validation errors' {
+        $missingArchive = Join-Path $TestDrive 'missing.zip'
+        $missingFile = Join-Path $TestDrive 'missing.txt'
+
+        InModuleScope RenderKit -Parameters @{
+            MissingArchive = $missingArchive
+            MissingFile = $missingFile
+        } {
+            {
+                Add-BackupFileToArchive `
+                    -ArchivePath $MissingArchive `
+                    -FilePath $MissingFile `
+                    -ErrorAction Stop
+            } | Should -Throw '*Archive*was not found*'
+        }
+    }
+}

--- a/src/Private/Backup/Add-BackupFileToArchive.ps1
+++ b/src/Private/Backup/Add-BackupFileToArchive.ps1
@@ -11,11 +11,19 @@ function Add-BackupFileToArchive {
     Write-RenderKitLog -Level Debug -Message "Add-BackupFileToArchive started: ArchivePath='$ArchivePath', FilePath='$FilePath', EntryPath='$EntryPath'."
 
     if (-not (Test-Path -Path $ArchivePath -PathType Leaf)) {
-        Write-RenderKitLog -Level Error -Message "Archive '$ArchivePath' was not found."
+        # RS-1518: The terminating validation exception is authoritative; keep
+        # its diagnostic log file-only to avoid a secondary ErrorRecord.
+        Write-RenderKitLog `
+            -Level Error `
+            -Message "Archive '$ArchivePath' was not found." `
+            -NoConsole
         throw "Archive '$ArchivePath' was not found."
     }
     if (-not (Test-Path -Path $FilePath -PathType Leaf)) {
-        Write-RenderKitLog -Level Error -Message "File '$FilePath' was not found."
+        Write-RenderKitLog `
+            -Level Error `
+            -Message "File '$FilePath' was not found." `
+            -NoConsole
         throw "File '$FilePath' was not found."
     }
 

--- a/src/Private/Backup/Add-BackupLogsToArchive.ps1
+++ b/src/Private/Backup/Add-BackupLogsToArchive.ps1
@@ -10,7 +10,12 @@ function Add-BackupLogsToArchive {
     Write-RenderKitLog -Level Debug -Message "Add-BackupLogsToArchive started: ArchivePath='$ArchivePath', ProjectRoot='$ProjectRoot'."
 
     if (-not (Test-Path -Path $ArchivePath -PathType Leaf)) {
-        Write-RenderKitLog -Level Error -Message "Archive '$ArchivePath' was not found."
+        # RS-1518: Keep diagnostics persistent without duplicating the
+        # terminating archive-not-found exception on PowerShell's error stream.
+        Write-RenderKitLog `
+            -Level Error `
+            -Message "Archive '$ArchivePath' was not found." `
+            -NoConsole
         throw "Archive '$ArchivePath' was not found."
     }
     if (-not (Test-Path -Path $ProjectRoot -PathType Container)) {

--- a/src/Private/Backup/Resolve-BackupArchivePath.ps1
+++ b/src/Private/Backup/Resolve-BackupArchivePath.ps1
@@ -17,7 +17,12 @@ function Resolve-BackupArchivePath {
     }
 
     if ([string]::IsNullOrWhiteSpace($effectiveDestinationRoot)) {
-        Write-RenderKitLog -Level Error -Message "Destination root could not be resolved."
+        # RS-1518: The throw below is the caller-facing failure. Keep the error
+        # log file-only so the same failure is not represented twice upstream.
+        Write-RenderKitLog `
+            -Level Error `
+            -Message "Destination root could not be resolved." `
+            -NoConsole
         throw "Destination root could not be resolved."
     }
 

--- a/src/Private/Backup/Save-BackupManifest.ps1
+++ b/src/Private/Backup/Save-BackupManifest.ps1
@@ -12,7 +12,12 @@ function Save-BackupManifest {
     $targetPath = $ManifestPath
     if ([string]::IsNullOrWhiteSpace($targetPath)) {
         if ([string]::IsNullOrWhiteSpace($ProjectRoot)) {
-            Write-RenderKitLog -Level Error -Message "Either -ProjectRoot or -ManifestPath must be provided."
+            # RS-1518: The terminating exception is the canonical PowerShell
+            # failure. Persist diagnostics without emitting a second ErrorRecord.
+            Write-RenderKitLog `
+                -Level Error `
+                -Message "Either -ProjectRoot or -ManifestPath must be provided." `
+                -NoConsole
             throw "Either -ProjectRoot or -ManifestPath must be provided."
         }
 

--- a/src/Private/Backup/Test-BackupArchiveContentIntegrity.ps1
+++ b/src/Private/Backup/Test-BackupArchiveContentIntegrity.ps1
@@ -12,11 +12,19 @@ function Test-BackupArchiveContentIntegrity {
     )
 
     if (-not (Test-Path -Path $ProjectPath -PathType Container)) {
-        Write-RenderKitLog -Level Error -Message "Project path '$ProjectPath' does not exist."
+        # RS-1518: Input validation throws are the canonical PowerShell errors.
+        # Persist diagnostics without emitting a second non-terminating record.
+        Write-RenderKitLog `
+            -Level Error `
+            -Message "Project path '$ProjectPath' does not exist." `
+            -NoConsole
         throw "Project path '$ProjectPath' does not exist."
     }
     if (-not (Test-Path -Path $ArchivePath -PathType Leaf)) {
-        Write-RenderKitLog -Level Error -Message "Archive path '$ArchivePath' does not exist."
+        Write-RenderKitLog `
+            -Level Error `
+            -Message "Archive path '$ArchivePath' does not exist." `
+            -NoConsole
         throw "Archive path '$ArchivePath' does not exist."
     }
 


### PR DESCRIPTION
## Summary

Prevent private backup validation paths from emitting a secondary PowerShell `ErrorRecord` when a terminating exception is already the canonical failure.

## Changes

- keep manifest path validation error logging file-only
- keep archive destination resolution error logging file-only
- keep backup log/file archive injection validation error logging file-only
- keep archive content integrity input validation error logging file-only
- preserve the existing terminating exceptions and persistent diagnostic logging
- keep the change scoped to private backup failure paths rather than altering the global logging contract
- document the canonical-error rule directly in the implementation with `RS-1518`
- add regression coverage for the hardened functions and canonical throws

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.