### PR TITLE
RS-1519: Harden FFmpeg probe compatibility on PowerShell 5.1

### DIFF
--- a/Tests/Backup/RenderKit.BackupGpuProbeCompatibility.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupGpuProbeCompatibility.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'RS-1508 FFmpeg hardware probe compatibility' {
+Describe 'FFmpeg hardware probe compatibility' {
     BeforeAll {
         $repositoryRoot = Split-Path -Parent (
             Split-Path -Parent $PSScriptRoot)
@@ -18,8 +18,9 @@ Describe 'RS-1508 FFmpeg hardware probe compatibility' {
         Remove-Module RenderKit -Force -ErrorAction SilentlyContinue
     }
 
-    It 'documents the compatibility fix under RS-1508' {
+    It 'documents the compatibility fixes for supported legacy hosts' {
         $implementationSource | Should -Match 'RS-1508'
+        $implementationSource | Should -Match 'RS-1519'
         $implementationSource | Should -Match 'Windows PowerShell 5\.1'
     }
 
@@ -30,6 +31,29 @@ Describe 'RS-1508 FFmpeg hardware probe compatibility' {
             $definition | Should -Match "PSObject\.Properties\.Name -contains 'ArgumentList'"
             $definition | Should -Match 'ConvertTo-BackupProbeArgumentText'
         }
+    }
+
+    It 'quotes whitespace, empty values, literal quotes and trailing backslashes for the legacy Arguments path' {
+        $result = InModuleScope RenderKit {
+            [PSCustomObject]@{
+                plain = ConvertTo-BackupProbeArgumentText -Arguments @('plain')
+                whitespace = ConvertTo-BackupProbeArgumentText -Arguments @('two words')
+                empty = ConvertTo-BackupProbeArgumentText -Arguments @('')
+                literalQuote = ConvertTo-BackupProbeArgumentText -Arguments @('quote"value')
+                trailingBackslash = ConvertTo-BackupProbeArgumentText `
+                    -Arguments @('path with space\')
+            }
+        }
+
+        $quote = [char]34
+        $backslash = [char]92
+        $result.plain | Should -Be 'plain'
+        $result.whitespace | Should -Be ($quote + 'two words' + $quote)
+        $result.empty | Should -Be ($quote.ToString() + $quote)
+        $result.literalQuote | Should -Be (
+            $quote + 'quote' + $backslash + $quote + 'value' + $quote)
+        $result.trailingBackslash | Should -Be (
+            $quote + 'path with space' + $backslash + $backslash + $quote)
     }
 
     It 'falls back when process-tree termination is unavailable' {

--- a/Tests/Backup/RenderKit.BackupGpuProbeCompatibility.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupGpuProbeCompatibility.Tests.ps1
@@ -48,15 +48,18 @@ Describe 'FFmpeg hardware probe compatibility' {
             }
         }
 
-        $quote = [char]34
-        $backslash = [char]92
+        $quoteText = ([char]34).ToString()
+        $backslashText = ([char]92).ToString()
         $result.plain | Should -Be 'plain'
-        $result.whitespace | Should -Be ($quote + 'two words' + $quote)
-        $result.empty | Should -Be ($quote.ToString() + $quote)
+        $result.whitespace | Should -Be (
+            $quoteText + 'two words' + $quoteText)
+        $result.empty | Should -Be ($quoteText + $quoteText)
         $result.literalQuote | Should -Be (
-            $quote + 'quote' + $backslash + $quote + 'value' + $quote)
+            $quoteText + 'quote' + $backslashText + $quoteText +
+            'value' + $quoteText)
         $result.trailingBackslash | Should -Be (
-            $quote + 'path with space' + $backslash + $backslash + $quote)
+            $quoteText + 'path with space' + $backslashText +
+            $backslashText + $quoteText)
     }
 
     It 'falls back when process-tree termination is unavailable' {

--- a/Tests/Backup/RenderKit.BackupGpuProbeCompatibility.Tests.ps1
+++ b/Tests/Backup/RenderKit.BackupGpuProbeCompatibility.Tests.ps1
@@ -35,13 +35,16 @@ Describe 'FFmpeg hardware probe compatibility' {
 
     It 'quotes whitespace, empty values, literal quotes and trailing backslashes for the legacy Arguments path' {
         $result = InModuleScope RenderKit {
+            $quote = [char]34
+            $backslash = [char]92
             [PSCustomObject]@{
                 plain = ConvertTo-BackupProbeArgumentText -Arguments @('plain')
                 whitespace = ConvertTo-BackupProbeArgumentText -Arguments @('two words')
                 empty = ConvertTo-BackupProbeArgumentText -Arguments @('')
-                literalQuote = ConvertTo-BackupProbeArgumentText -Arguments @('quote"value')
+                literalQuote = ConvertTo-BackupProbeArgumentText `
+                    -Arguments @(('quote' + $quote + 'value'))
                 trailingBackslash = ConvertTo-BackupProbeArgumentText `
-                    -Arguments @('path with space\')
+                    -Arguments @(('path with space' + $backslash))
             }
         }
 

--- a/src/Private/Backup/RenderKit.BackupGpuProbeCompatibility.ps1
+++ b/src/Private/Backup/RenderKit.BackupGpuProbeCompatibility.ps1
@@ -1,5 +1,61 @@
 # RS-1508: Keep the hardware encoder probe compatible with Windows PowerShell 5.1
 # while preserving the hosted-runspace-safe process handling used by newer runtimes.
+function ConvertTo-BackupProbeArgumentText {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string[]]$Arguments
+    )
+
+    # RS-1519: ProcessStartInfo.Arguments is one command-line string on .NET
+    # Framework. Quote each argument using the Windows command-line escaping
+    # rules: backslashes before a literal quote are doubled, and trailing
+    # backslashes are doubled before the closing quote. Simple arguments stay
+    # untouched so the modern ArgumentList and legacy Arguments paths remain
+    # semantically equivalent.
+    $escaped = foreach ($argumentValue in @($Arguments)) {
+        $argument = [string]$argumentValue
+        if ($argument.Length -gt 0 -and $argument -notmatch '[\s"]') {
+            $argument
+            continue
+        }
+
+        $builder = New-Object System.Text.StringBuilder
+        [void]$builder.Append('"')
+        $backslashCount = 0
+
+        foreach ($character in $argument.ToCharArray()) {
+            if ($character -eq '\') {
+                $backslashCount++
+                continue
+            }
+
+            if ($character -eq '"') {
+                if ($backslashCount -gt 0) {
+                    [void]$builder.Append(('\' * ($backslashCount * 2)))
+                }
+                [void]$builder.Append('\"')
+                $backslashCount = 0
+                continue
+            }
+
+            if ($backslashCount -gt 0) {
+                [void]$builder.Append(('\' * $backslashCount))
+                $backslashCount = 0
+            }
+            [void]$builder.Append($character)
+        }
+
+        if ($backslashCount -gt 0) {
+            [void]$builder.Append(('\' * ($backslashCount * 2)))
+        }
+        [void]$builder.Append('"')
+        $builder.ToString()
+    }
+
+    return ($escaped -join ' ')
+}
+
 function Test-BackupFfmpegEncoderCapability {
     [CmdletBinding()]
     param(
@@ -10,21 +66,6 @@ function Test-BackupFfmpegEncoderCapability {
         [ValidateRange(1, 60)]
         [int]$TimeoutSeconds = 15
     )
-
-    function ConvertTo-BackupProbeArgumentText {
-        param([string[]]$Arguments)
-
-        $escaped = foreach ($argument in @($Arguments)) {
-            if ($argument -match '[\s"]') {
-                '"' + ($argument -replace '"', '\"') + '"'
-            }
-            else {
-                $argument
-            }
-        }
-
-        return ($escaped -join ' ')
-    }
 
     $arguments = @(
         '-hide_banner',

--- a/src/Private/Backup/RenderKit.BackupGpuProbeCompatibility.ps1
+++ b/src/Private/Backup/RenderKit.BackupGpuProbeCompatibility.ps1
@@ -13,6 +13,10 @@ function ConvertTo-BackupProbeArgumentText {
     # backslashes are doubled before the closing quote. Simple arguments stay
     # untouched so the modern ArgumentList and legacy Arguments paths remain
     # semantically equivalent.
+    $quote = [char]34
+    $backslash = [char]92
+    $backslashText = $backslash.ToString()
+
     $escaped = foreach ($argumentValue in @($Arguments)) {
         $argument = [string]$argumentValue
         if ($argument.Length -gt 0 -and $argument -notmatch '[\s"]') {
@@ -21,35 +25,39 @@ function ConvertTo-BackupProbeArgumentText {
         }
 
         $builder = New-Object System.Text.StringBuilder
-        [void]$builder.Append('"')
+        [void]$builder.Append($quote)
         $backslashCount = 0
 
         foreach ($character in $argument.ToCharArray()) {
-            if ($character -eq '\') {
+            if ($character -eq $backslash) {
                 $backslashCount++
                 continue
             }
 
-            if ($character -eq '"') {
+            if ($character -eq $quote) {
                 if ($backslashCount -gt 0) {
-                    [void]$builder.Append(('\' * ($backslashCount * 2)))
+                    [void]$builder.Append(
+                        ($backslashText * ($backslashCount * 2)))
                 }
-                [void]$builder.Append('\"')
+                [void]$builder.Append($backslash)
+                [void]$builder.Append($quote)
                 $backslashCount = 0
                 continue
             }
 
             if ($backslashCount -gt 0) {
-                [void]$builder.Append(('\' * $backslashCount))
+                [void]$builder.Append(
+                    ($backslashText * $backslashCount))
                 $backslashCount = 0
             }
             [void]$builder.Append($character)
         }
 
         if ($backslashCount -gt 0) {
-            [void]$builder.Append(('\' * ($backslashCount * 2)))
+            [void]$builder.Append(
+                ($backslashText * ($backslashCount * 2)))
         }
-        [void]$builder.Append('"')
+        [void]$builder.Append($quote)
         $builder.ToString()
     }
 


### PR DESCRIPTION
## Summary

Harden the FFmpeg hardware encoder probe's legacy `ProcessStartInfo.Arguments` path for Windows PowerShell 5.1 while keeping the modern `ArgumentList` path unchanged.

## Changes

- keep feature detection for `ProcessStartInfo.ArgumentList`
- replace the simple legacy argument joiner with Windows command-line compatible quoting
- correctly escape literal quotes and backslashes preceding quotes
- correctly double trailing backslashes before a closing quoted argument
- preserve empty arguments and simple unquoted arguments
- keep process timeout, redirected stream draining, and process-tree kill fallback behavior unchanged
- document the compatibility rule directly in the implementation with `RS-1519`
- add regression coverage for whitespace, empty, quoted, and trailing-backslash arguments

## Validation

The Quality Gate matrix covers Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS.