### PR TITLE
Prepare RenderKit 1.1.6 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.1.6] - 2026-08-22
+
+RenderKit 1.1.6 is a filesystem-compatibility patch release focused on reliable
+read access to packaged resources from protected installation locations.
+
+### Fixed
+
+- **RS-1552:** Fixed provider-specific JSON reads failing against valid read-only packaged resources under protected installation locations such as `C:\Program Files`. JSON reads now use provider-neutral .NET file APIs, preserve retry, size-limit and validation behavior, and report access/I/O failures separately from malformed JSON.
+
 ## [1.1.5] - 2026-08-14
 
 RenderKit 1.1.5 is a patch release focused on runtime safety, durable job execution,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **RenderKit** is a free and open-source PowerShell toolkit for video editors, media creators, and small production teams who want repeatable project folders, safer media imports, simple delivery packages, and auditable backups.
 
-Current repository version: **1.1.5**. RenderKit supports **Windows PowerShell 5.1** and **PowerShell 7+**.
+Current repository version: **1.1.6**. RenderKit supports **Windows PowerShell 5.1** and **PowerShell 7+**.
 
 RenderKit is currently the workflow/engine foundation for a future local-first MAM/DAM-style tool. Think of it as the practical workflow layer around your editing software: project setup, ingest discipline, transfer checks, packaging, and backup structure.
 
@@ -294,7 +294,7 @@ Key technical documents:
 ## Public Functions
 
 The [complete public-function reference](docs/public-functions.md) lists every
-command exported by the 1.1.5 manifest. Detailed workflow documentation is
+command exported by the 1.1.6 manifest. Detailed workflow documentation is
 grouped by [projects](docs/project-lifecycle.md), [metadata](docs/metadata.md),
 [clients](docs/client-registry.md), [publishing](docs/publishing.md), and
 [backup/jobs](docs/backup-operations.md).

--- a/RenderKit.psd1
+++ b/RenderKit.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'RenderKit.psm1'
-    ModuleVersion = '1.1.5' # Major.Minor.Patch
+    ModuleVersion = '1.1.6' # Major.Minor.Patch
     Author = 'Norbert Marton'
     Description = 'PowerShell tools for structured video editing project workflows.'
     GUID = '32e3f476-8e44-4511-82c7-952748e6463b'
@@ -101,14 +101,10 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-Version 1.1.5 is a runtime-safety and cross-platform reliability patch release:
-- RS-1508 removes cross-thread PowerShell process callbacks from parallel backup workers, preserves FFmpeg progress streaming, and keeps the canonical terminating error from being masked by secondary ErrorRecords.
-- RS-1511 and RS-1512 harden durable jobs by preserving handler-owned persisted states and making event-to-job deduplication atomic inside the JobStore transaction.
-- RS-1513, RS-1515, and RS-1516 make worker diagnostics best-effort, guard PID recovery by explicit host ownership, and normalize portable manifest/job audit identity without mutating caller-owned context.
-- RS-1514 makes backup-lock ownership portable and stale-lock takeover race-safe on local and shared project paths.
-- RS-1517, RS-1518, and RS-1519 fix platform-native project metadata paths, duplicate backup error records, and Windows PowerShell 5.1 FFmpeg probe argument/termination compatibility.
-- RS-1520 serializes release publishing, requires the successful Quality Gate for the exact main commit, validates local and Gallery installation paths before the final GitHub Release, and refuses to overwrite existing release versions.
-- No public command or persisted JobStore/EventStore schema changes are introduced by this patch release.
+Version 1.1.6 is a filesystem-compatibility patch release:
+- RS-1552 makes JSON reads provider-neutral so packaged system resources remain readable from protected installation locations such as Program Files without requiring write access.
+- JSON parsing failures remain distinct from file I/O and access failures while existing retry, size-limit, validation, and atomic-write behavior is preserved.
+- No public command or persisted schema changes are introduced by this patch release.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
## Summary

Prepare the RenderKit `1.1.6` release branch for the RS-1552 filesystem-compatibility hotfix.

This release is intentionally scoped as a patch release. It updates the module/repository version metadata and adds the dedicated `1.1.6` changelog section. The runtime fix is developed separately in #101 against this branch and will be merged here before this release PR is finalized.

## Planned 1.1.6 scope

- keep valid bundled JSON resources readable from protected installation locations such as `C:\Program Files`
- remove provider-specific read behavior from the JSON persistence path where it can require access that a normal read does not need
- preserve existing retry, size-limit, validation and atomic-write behavior
- distinguish malformed JSON from filesystem/access failures
- add regression coverage for protected/resource reads and bundled system templates
- no public command or persisted schema changes

## Release metadata

- `RenderKit.psd1`: `1.1.6`
- README release references: `1.1.6`
- `CHANGELOG.md`: new `1.1.6` section dated 2026-08-22

## Merge order

1. Review this release branch as the target for the hotfix.
2. Merge #101 into `1.1.6`.
3. Re-run the complete quality/release validation on the resulting release branch.
4. Finalize and merge this PR into `main` only when the patch is ready to publish.