### PR TITLE
RS-1552 Fix packaged JSON reads from protected install locations

### DIFF
--- a/Tests/Public/RenderKit.ResourcePortability.Tests.ps1
+++ b/Tests/Public/RenderKit.ResourcePortability.Tests.ps1
@@ -29,6 +29,17 @@ Describe 'RenderKit template and mapping portability' {
 
     AfterEach { Remove-Item Env:RENDERKIT_HOME -ErrorAction SilentlyContinue }
 
+    It 'reads bundled system templates through the canonical JSON reader' {
+        foreach ($templateName in @('default', 'minimal', 'podcast')) {
+            $template = Get-ProjectTemplate -TemplateName $templateName
+
+            $template.Name | Should -Be $templateName
+            [string]::IsNullOrWhiteSpace([string]$template.Version) |
+                Should -BeFalse
+            $null -eq $template.Folders | Should -BeFalse
+        }
+    }
+
     It 'imports, validates, exports, and renames templates' {
         $source = Join-Path $TestDrive 'template.json'
         @{ Version = '1.1'; Name = 'portable'; Folders = @(); Mappings = @(); Deliverables = @() } |

--- a/Tests/Storage/RenderKit.PersistenceService.Tests.ps1
+++ b/Tests/Storage/RenderKit.PersistenceService.Tests.ps1
@@ -30,6 +30,56 @@ Describe 'RenderKit JSON persistence service' {
         $bytes[0] | Should -Be 0x7B
     }
 
+    It 'reads valid JSON without PowerShell provider Force access' {
+        Set-Content `
+            -LiteralPath $script:jsonPath `
+            -Value '{"Name":"PackagedResource","Version":1}' `
+            -Encoding UTF8
+
+        Mock Get-Item {
+            throw [System.UnauthorizedAccessException]::new(
+                'Provider access should not be required.')
+        }
+        Mock Get-Content {
+            throw [System.UnauthorizedAccessException]::new(
+                'Provider access should not be required.')
+        }
+
+        $value = Read-RenderKitJsonFile -Path $script:jsonPath
+
+        $value.Name | Should -Be 'PackagedResource'
+        $value.Version | Should -Be 1
+    }
+
+    It 'keeps filesystem access failures distinct from invalid JSON' {
+        Set-Content `
+            -LiteralPath $script:jsonPath `
+            -Value '{"Version":1}' `
+            -Encoding UTF8
+        Mock Read-RenderKitTextFile {
+            throw [System.UnauthorizedAccessException]::new('Access denied.')
+        } -ParameterFilter {
+            $Path -eq $script:jsonPath
+        }
+
+        {
+            Read-RenderKitJsonFile `
+                -Path $script:jsonPath `
+                -ReadRetryCount 0
+        } | Should -Throw '*Unable to read JSON file*Access denied*'
+    }
+
+    It 'reports malformed content as invalid JSON' {
+        Set-Content `
+            -LiteralPath $script:jsonPath `
+            -Value '{invalid' `
+            -Encoding UTF8
+
+        {
+            Read-RenderKitJsonFile -Path $script:jsonPath
+        } | Should -Throw '*Invalid JSON*'
+    }
+
     It 'validates atomic JSON through a hidden sibling path' {
         $hiddenPath = Join-Path $script:testRoot '.metadata.json'
 
@@ -50,7 +100,7 @@ Describe 'RenderKit JSON persistence service' {
             -Value '{"Version":3}' `
             -Encoding UTF8
         $script:readAttempts = 0
-        Mock Get-Content {
+        Mock Read-RenderKitTextFile {
             $script:readAttempts++
             if ($script:readAttempts -eq 1) {
                 throw [System.IO.FileNotFoundException]::new(
@@ -58,7 +108,7 @@ Describe 'RenderKit JSON persistence service' {
             }
             return '{"Version":3}'
         } -ParameterFilter {
-            $LiteralPath -eq $script:jsonPath
+            $Path -eq $script:jsonPath
         }
 
         $value = Read-RenderKitJsonFile `

--- a/src/Private/Storage/RenderKit.PersistenceService.ps1
+++ b/src/Private/Storage/RenderKit.PersistenceService.ps1
@@ -87,6 +87,20 @@ function Test-RenderKitJsonValue {
     }
 }
 
+function Read-RenderKitTextFile {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    # RS-1552: JSON resources can live below protected application locations
+    # such as Program Files. Reading them must not depend on PowerShell provider
+    # -Force semantics or require any write-capable access to the parent path.
+    return [System.IO.File]::ReadAllText($Path)
+}
+
 function Read-RenderKitJsonFile {
     [CmdletBinding()]
     param(
@@ -110,46 +124,70 @@ function Read-RenderKitJsonFile {
     $resolvedPath = [System.IO.Path]::GetFullPath($Path)
     $value = $null
     $lastReadError = $null
+    $lastFailureKind = $null
+
     for ($attempt = 0; $attempt -le $ReadRetryCount; $attempt++) {
-        if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
-            if ($AllowMissing) {
-                return $null
-            }
-            $lastReadError = [System.IO.FileNotFoundException]::new(
-                "JSON file not found: '$resolvedPath'.")
-        }
-        else {
-            try {
-                # Atomic candidates intentionally start with a dot. On Unix,
-                # PowerShell treats those paths as hidden and requires -Force
-                # even when the literal file name is already known.
-                $item = Get-Item `
-                    -LiteralPath $resolvedPath `
-                    -Force `
-                    -ErrorAction Stop
-                if ($item.Length -gt $MaximumBytes) {
-                    throw "JSON file '$resolvedPath' exceeds the $MaximumBytes byte limit."
+        try {
+            $fileInfo = [System.IO.FileInfo]::new($resolvedPath)
+            if (-not $fileInfo.Exists) {
+                if ($AllowMissing) {
+                    return $null
                 }
-                $value = Get-Content `
-                    -LiteralPath $resolvedPath `
-                    -Raw `
-                    -Force `
-                    -ErrorAction Stop |
-                    ConvertFrom-Json -ErrorAction Stop
-                $lastReadError = $null
+
+                throw [System.IO.FileNotFoundException]::new(
+                    "JSON file not found: '$resolvedPath'.")
+            }
+
+            if ($fileInfo.Length -gt $MaximumBytes) {
+                $lastReadError = [System.IO.InvalidDataException]::new(
+                    "JSON file '$resolvedPath' exceeds the $MaximumBytes byte limit.")
+                $lastFailureKind = 'Limit'
                 break
+            }
+
+            $jsonText = Read-RenderKitTextFile -Path $resolvedPath
+            try {
+                $value = $jsonText | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
                 $lastReadError = $_.Exception
+                $lastFailureKind = 'Json'
+                break
             }
+
+            $lastReadError = $null
+            $lastFailureKind = $null
+            break
+        }
+        catch [System.IO.FileNotFoundException] {
+            $lastReadError = $_.Exception
+            $lastFailureKind = 'Missing'
+        }
+        catch {
+            $lastReadError = $_.Exception
+            $lastFailureKind = 'Read'
         }
 
         if ($attempt -lt $ReadRetryCount) {
             Start-Sleep -Milliseconds $ReadRetryMilliseconds
         }
     }
+
     if ($lastReadError) {
-        throw "Invalid JSON in '$resolvedPath': $($lastReadError.Message)"
+        switch ($lastFailureKind) {
+            'Json' {
+                throw "Invalid JSON in '$resolvedPath': $($lastReadError.Message)"
+            }
+            'Limit' {
+                throw $lastReadError.Message
+            }
+            'Missing' {
+                throw $lastReadError.Message
+            }
+            default {
+                throw "Unable to read JSON file '$resolvedPath': $($lastReadError.Message)"
+            }
+        }
     }
 
     if ($null -eq $value) {

--- a/src/Private/Template/RenderKit.TemplateService.ps1
+++ b/src/Private/Template/RenderKit.TemplateService.ps1
@@ -94,8 +94,13 @@ function Read-RenderKitTemplateFile {
         return Read-RenderKitJsonFile -Path $Path
     }
     catch {
-        Write-RenderKitLog -Level Error -Message "Invalid JSON in template '$Path'."
-        throw "Invalid JSON in template '$Path'"
+        # RS-1552: Keep filesystem/access failures distinguishable from an
+        # actual JSON parse failure. The persistence layer already classifies
+        # the cause, so template loading must not replace it with a generic
+        # "Invalid JSON" message.
+        $message = "Failed to read template '$Path': $($_.Exception.Message)"
+        Write-RenderKitLog -Level Error -Message $message
+        throw $message
     }
 }
 


### PR DESCRIPTION
## Ticket

RS-1552

## Problem

Valid bundled JSON resources can be read normally from protected installation paths such as `C:\Program Files`, but RenderKit's JSON persistence helper used PowerShell provider access with `-Force`. In the packaged Studio runtime this could fail with `Access denied` and was then incorrectly surfaced as `Invalid JSON`, preventing project creation from valid system templates.

## Fix

- read JSON payloads through provider-neutral .NET file APIs
- keep the existing maximum-size guard, retry behavior, `AllowMissing` behavior and validation hook
- keep atomic write/backup/transaction behavior unchanged
- distinguish malformed JSON from filesystem/access failures
- preserve the underlying read failure when template loading reports an error
- cover provider-denied PowerShell reads while the .NET read path remains valid
- cover filesystem access failures separately from malformed JSON
- exercise the bundled `default`, `minimal` and `podcast` system templates through the canonical template/JSON reader

## Compatibility

- no public command changes
- no persisted schema changes
- Windows PowerShell 5.1 and PowerShell 7+ remain supported
- existing atomic persistence semantics remain unchanged

## Validation

Focused persistence and resource-portability regression coverage is included. Full CI/Quality Gate is expected to validate the complete branch before merge.